### PR TITLE
Remove maintainers field from OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,5 +4,3 @@ reviewers:
 - Elbehery
 approvers:
 - tjungblu
-maintainers:
-- tjungblu


### PR DESCRIPTION
Removed `maintainers` field which is not part of the OWNERS [configuration](https://github.com/kubernetes/test-infra/blob/master/prow/repoowners/repoowners.go#L56-L61).