### PR TITLE
Added a linter target with golangci-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ must-gather-clean
 
 # Goland IDE
 .idea
+
+# Tools Directory
+bin/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,88 @@
+# This file contains all available configuration options
+# with their default values.
+
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 1m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # include test files or not, default is true
+  tests: true
+
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  # "/" will be replaced by current OS file path separator to properly work
+  # on Windows.
+  skip-dirs:
+    - vendor
+    - pkg/tools
+  
+  skip-files:
+    - pkg/schema/schema.go
+
+  # default is true. Enables skipping of directories:
+  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs-use-default: true
+
+  # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
+  # If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # automatic updating of go.mod described above. Instead, it fails when any changes
+  # to go.mod are needed. This setting is most useful to check that go.mod does
+  # not need updates, such as in a continuous integration and testing system.
+  # If invoked with -mod=vendor, the go command assumes that the vendor
+  # directory holds the correct copies of dependencies and ignores
+  # the dependency descriptions in go.mod.
+  modules-download-mode: vendor
+
+  # Allow multiple parallel golangci-lint instances running.
+  # If false (default) - golangci-lint acquires file lock on start.
+  allow-parallel-runners: false
+
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  # default is "colored-line-number"
+  format: tab
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
+  # add a prefix to the output file references; default is no prefix
+  path-prefix: ""
+
+  # sorts results by: filepath, line and column
+  sort-results: false
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+  fast: false
+

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,10 @@ verify: verify-scripts
 update-scripts:
 	hack/update-apigen.sh
 .PHONY: update-scripts
+
+ensure-golangci-lint:
+	hack/ensure-golangci-lint.sh
+.PHONY: ensure-golangci-lint
+
+lint: ensure-golangci-lint
+	bin/golangci-lint -c .golangci.yaml run

--- a/cmd/must-gather-clean/root.go
+++ b/cmd/must-gather-clean/root.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/openshift/must-gather-clean/pkg/cli"
-	"github.com/spf13/cobra"
 	"math/rand"
 	"os"
 	"time"
+
+	"github.com/openshift/must-gather-clean/pkg/cli"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+VERSION=1.41.1
+GOOS=$(go env GOOS)
+TARNAME=golangci-lint-$VERSION-$GOOS-amd64.tar.gz
+URL=https://github.com/golangci/golangci-lint/releases/download/v$VERSION/$TARNAME
+GOLANGCI_LINT=bin/golangci-lint
+
+case $GOOS in
+    linux)
+        CHECKSUM=2ad1b2313f89d8ecb35f2e4d2463cf5bc1e057518e4c523565f09416046c21f7
+        ;;
+    darwin)
+        CHECKSUM=458f15c43f72b0bd905ff165c42cf474e5510f91f4a10ae025e42e22fe8b578f
+        ;;
+    *)
+        echo "Unknown GOOS $GOOS"
+        exit 1
+        ;;
+esac
+
+# If golangci-lint exists locally verify checksum
+if [ -f $GOLANGCI_LINT ]; then
+    if echo "$CHECKSUM $GOLANGCI_LINT" | sha256sum --check --quiet ; then
+        exit 0
+    else
+        rm -f $GOLANGCI_LINT
+    fi
+fi
+
+DESTINATION=$(mktemp -d)
+curl -L -o "$DESTINATION/golangci-lint.tar.gz" "$URL"
+tar xzf "$DESTINATION/golangci-lint.tar.gz" --directory="$DESTINATION"
+
+mkdir -p bin
+mv "$DESTINATION/golangci-lint-$VERSION-$GOOS-amd64/golangci-lint" $GOLANGCI_LINT
+
+if echo "$CHECKSUM $GOLANGCI_LINT" | sha256sum --check --quiet ; then
+    echo "golangci-lint downloaded and verified."
+    exit 0
+else
+    echo "Checksum of downloaded golangci-lint cannot be verified."
+    exit 1
+fi

--- a/pkg/schema/schema_reader.go
+++ b/pkg/schema/schema_reader.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"sigs.k8s.io/yaml"
 	"strings"
+
+	"sigs.k8s.io/yaml"
 )
 
 const jsonExtension = ".json"

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -1,9 +1,10 @@
 package schema
 
 import (
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidFiles(t *testing.T) {


### PR DESCRIPTION
[golangci-lint](https://golangci-lint.run/) is a collection of linters which can be configured through a single configuration. Added a make target to download the golangci-lint binary and store it locally. The script can also check the local version and download a newer version if required.

Also included are formatting changes for imports.