### PR TITLE
Added obfuscator for IP Addresses

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -32,6 +32,8 @@ func Run(configPath string, inputPath string, outputPath string) error {
 			obfuscators = append(obfuscators, o)
 		case schema.ObfuscateTypeDomain:
 			obfuscators = append(obfuscators, obfuscator.NewDomainObfuscator(config.Config.TopLevelDomains))
+		case schema.ObfuscateTypeIP:
+			obfuscators = append(obfuscators, obfuscator.NewIPObfuscator())
 		}
 	}
 

--- a/pkg/obfuscator/ip.go
+++ b/pkg/obfuscator/ip.go
@@ -1,0 +1,61 @@
+package obfuscator
+
+import (
+	"net"
+	"regexp"
+	"strings"
+)
+
+const (
+	obfuscatedStaticIPv4 = "xxx.xxx.xxx.xxx"
+	obfuscatedStaticIPv6 = "xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx"
+)
+
+var (
+	ipv4re = `(([0-9]{1,3})\.){3}([0-9]{1,3})`
+	// ipv6re is not perfect. it can still catch words like :face:bad as a valid ipv6 address
+	ipv6re = `([a-f0-9]{0,4}:){1,8}[a-f0-9]{1,4}`
+)
+
+type ipObfuscator struct {
+	ReplacementReporter
+	ipv4pattern *regexp.Regexp
+	ipv6pattern *regexp.Regexp
+}
+
+func (o *ipObfuscator) FileName(s string) string {
+	return o.replace(s)
+}
+
+func (o *ipObfuscator) Contents(s string) string {
+	return o.replace(s)
+}
+
+func (o *ipObfuscator) replace(s string) string {
+	output := s
+	ipv4matches := o.ipv4pattern.FindAllString(output, -1)
+	for _, m := range ipv4matches {
+		if ip := net.ParseIP(m); ip != nil {
+			output = strings.ReplaceAll(output, m, obfuscatedStaticIPv4)
+			o.ReportReplacement(m, obfuscatedStaticIPv4)
+		}
+	}
+
+	ipv6matches := o.ipv6pattern.FindAllString(output, -1)
+	for _, m := range ipv6matches {
+		if ip := net.ParseIP(m); ip != nil {
+			output = strings.ReplaceAll(output, m, obfuscatedStaticIPv6)
+			o.ReportReplacement(m, obfuscatedStaticIPv6)
+		}
+	}
+
+	return output
+}
+
+func NewIPObfuscator() Obfuscator {
+	return &ipObfuscator{
+		ipv4pattern:         regexp.MustCompile(ipv4re),
+		ipv6pattern:         regexp.MustCompile(ipv6re),
+		ReplacementReporter: NewSimpleReporter(),
+	}
+}

--- a/pkg/obfuscator/ip_test.go
+++ b/pkg/obfuscator/ip_test.go
@@ -1,0 +1,68 @@
+package obfuscator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPObfuscator(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		input  string
+		output string
+		report map[string]string
+	}{
+		{
+			name:   "valid ipv4 address",
+			input:  "received request from 192.168.1.10",
+			output: "received request from xxx.xxx.xxx.xxx",
+			report: map[string]string{"192.168.1.10": obfuscatedStaticIPv4},
+		},
+		{
+			name:   "invalid ipv4 address",
+			input:  "value 910.218.98.1 is not an ipv4",
+			output: "value 910.218.98.1 is not an ipv4",
+			report: map[string]string{},
+		},
+		{
+			name:   "ipv4 in words",
+			input:  "calling https://192.168.1.20/metrics for values",
+			output: "calling https://xxx.xxx.xxx.xxx/metrics for values",
+			report: map[string]string{"192.168.1.20": obfuscatedStaticIPv4},
+		},
+		{
+			name:   "multiple ipv4s",
+			input:  "received request from 192.168.1.20 proxied through 192.168.1.3",
+			output: "received request from xxx.xxx.xxx.xxx proxied through xxx.xxx.xxx.xxx",
+			report: map[string]string{
+				"192.168.1.20": obfuscatedStaticIPv4,
+				"192.168.1.3":  obfuscatedStaticIPv4,
+			},
+		},
+		{
+			name:   "valid ipv6 address",
+			input:  "received request from 2001:db8::ff00:42:8329",
+			output: "received request from xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx",
+			report: map[string]string{
+				"2001:db8::ff00:42:8329": obfuscatedStaticIPv6,
+			},
+		},
+		{
+			name:   "mixed ipv4 and ipv6",
+			input:  "tunneling ::2fa:bf9 as 192.168.1.30",
+			output: "tunneling xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx as xxx.xxx.xxx.xxx",
+			report: map[string]string{
+				"192.168.1.30": obfuscatedStaticIPv4,
+				"::2fa:bf9":    obfuscatedStaticIPv6,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			o := NewIPObfuscator()
+			output := o.Contents(tc.input)
+			assert.Equal(t, tc.output, output)
+			assert.Equal(t, tc.report, o.ReportingResult())
+		})
+	}
+}


### PR DESCRIPTION
The obfuscator uses regular expressions to detect strings which are like IPv4 and IPv6 addresses and then uses the ParseIP library to verify if the detected string is actually valid.