### PR TITLE
Consistent replacements for obfuscated IP addresses

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -33,7 +33,11 @@ func Run(configPath string, inputPath string, outputPath string) error {
 		case schema.ObfuscateTypeDomain:
 			obfuscators = append(obfuscators, obfuscator.NewDomainObfuscator(config.Config.TopLevelDomains))
 		case schema.ObfuscateTypeIP:
-			obfuscators = append(obfuscators, obfuscator.NewIPObfuscator())
+			o, err := obfuscator.NewIPObfuscator(o.ReplacementType)
+			if err != nil {
+				return err
+			}
+			obfuscators = append(obfuscators, o)
 		}
 	}
 

--- a/pkg/obfuscator/replacement_reporter.go
+++ b/pkg/obfuscator/replacement_reporter.go
@@ -12,6 +12,9 @@ type ReplacementReporter interface {
 	// ReportReplacement will add a replacement along with its original string to the report.
 	// If there is an existing value that does not match the given replacement, it will panic as this very likely denotes a bug.
 	ReportReplacement(original string, replacement string)
+
+	// GetReplacement returns the previously used replacement if already set, otherwise returns an empty string
+	GetReplacement(original string) string
 }
 
 type SimpleReporter struct {
@@ -30,6 +33,10 @@ func (s *SimpleReporter) ReportReplacement(original string, replacement string) 
 	}
 
 	s.mapping[original] = replacement
+}
+
+func (s *SimpleReporter) GetReplacement(original string) string {
+	return s.mapping[original]
 }
 
 func NewSimpleReporter() ReplacementReporter {

--- a/pkg/obfuscator/replacement_reporter_test.go
+++ b/pkg/obfuscator/replacement_reporter_test.go
@@ -21,3 +21,10 @@ func TestSimpleReportingExistingReplacements(t *testing.T) {
 		r.ReportReplacement("a", "c")
 	}, "'a' already has a value reported as 'b', tried to report 'c'")
 }
+
+func TestSimpleReporterGetReplacement(t *testing.T) {
+	r := NewSimpleReporter()
+	r.ReportReplacement("a", "b")
+	assert.Equal(t, r.GetReplacement("a"), "b")
+	assert.Equal(t, r.GetReplacement("c"), "")
+}

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -19,6 +19,10 @@ import (
 type noopObfuscator struct {
 }
 
+func (d noopObfuscator) GetReplacement(original string) string {
+	return original
+}
+
 func (d noopObfuscator) FileName(input string) string {
 	return input
 }


### PR DESCRIPTION
Added a `GetReplacement()` method to the `ReplacementReporter` interface which returns a replacement if already present. This is leveraged by the IP obfuscator to find existing obfuscated values to consistently replace the same IP address with the same generated obfuscated value.