### PR TITLE
File omission based on file glob

### DIFF
--- a/pkg/input/filesystem.go
+++ b/pkg/input/filesystem.go
@@ -78,7 +78,7 @@ type fileSystemInput struct {
 }
 
 func (f *fileSystemInput) Root() Directory {
-	return newFsDir(f, "/", f.info)
+	return newFsDir(f, "", f.info)
 }
 
 func (f *fileSystemInput) Path() string {

--- a/pkg/input/filesystem_test.go
+++ b/pkg/input/filesystem_test.go
@@ -13,9 +13,9 @@ func TestFileSystemInput(t *testing.T) {
 	entries, err := input.Root().Entries()
 	require.NoError(t, err)
 	assert.Len(t, entries, 3)
-	assertContains(t, entries, "/test1.yaml", true)
-	assertContains(t, entries, "/test2.yaml", true)
-	assertContains(t, entries, "/testdir", false)
+	assertContains(t, entries, "test1.yaml", true)
+	assertContains(t, entries, "test2.yaml", true)
+	assertContains(t, entries, "testdir", false)
 }
 
 func assertContains(t *testing.T, entries []DirEntry, path string, file bool) {

--- a/pkg/omitter/fileomitter.go
+++ b/pkg/omitter/fileomitter.go
@@ -6,8 +6,14 @@ type fileOmitter struct {
 	filePattern string
 }
 
-func (f *fileOmitter) File(filename, _ string) (bool, error) {
-	return filepath.Match(f.filePattern, filename)
+func (f *fileOmitter) File(name, path string) (bool, error) {
+	match, err := filepath.Match(f.filePattern, path)
+	// if there is a match or an error return now
+	if match || err != nil {
+		return match, err
+	}
+	// else check for match with file name
+	return filepath.Match(f.filePattern, name)
 }
 
 func (f *fileOmitter) Contents(_ string) (bool, error) {

--- a/pkg/omitter/fileomitter_test.go
+++ b/pkg/omitter/fileomitter_test.go
@@ -1,6 +1,7 @@
 package omitter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,15 +21,28 @@ func TestFileOmitter(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "log files with path",
+			pattern:  "*.log",
+			input:    "ingress/pods/application.log",
+			expected: true,
+		},
+		{
 			name:     "text file with log pattern",
 			pattern:  "*.log",
 			input:    "application.log.txt",
 			expected: false,
 		},
+		{
+			name:     "path glob",
+			pattern:  "release-4.10/ingress_controllers/*/haproxy.*",
+			input:    "release-4.10/ingress_controllers/pod1/haproxy.conf",
+			expected: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			omitter := NewFilenamePatternOmitter(tc.pattern)
-			omit, err := omitter.File(tc.input, "")
+			parts := strings.Split(tc.input, "/")
+			omit, err := omitter.File(parts[len(parts)-1], tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, omit)
 		})


### PR DESCRIPTION
The file omitter can use the same pattern to also match against full paths instead of just the filename.

This PR requires #17 so that the relative paths from within the input directory are available within the `FileWalker`.

Also removes the `/` from the input reader so that filepath globs without the leading slash can match.