### PR TITLE
Validate the input for file omitter in New function

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -46,10 +46,11 @@ func Run(configPath string, inputPath string, outputPath string) error {
 	for _, o := range config.Config.Omit {
 		switch o.Type {
 		case schema.OmitTypeFile:
-			if *o.Pattern == "" {
-				return fmt.Errorf("no pattern specified for file omitter")
+			om, err := omitter.NewFilenamePatternOmitter(*o.Pattern)
+			if err != nil {
+				return err
 			}
-			omitters = append(omitters, omitter.NewFilenamePatternOmitter(*o.Pattern))
+			omitters = append(omitters, om)
 		}
 	}
 

--- a/pkg/omitter/fileomitter.go
+++ b/pkg/omitter/fileomitter.go
@@ -1,6 +1,9 @@
 package omitter
 
-import "path/filepath"
+import (
+	"errors"
+	"path/filepath"
+)
 
 type fileOmitter struct {
 	filePattern string
@@ -21,6 +24,9 @@ func (f *fileOmitter) Contents(_ string) (bool, error) {
 }
 
 // NewFilenamePatternOmitter return an omitter which omits files based on a globbing pattern.
-func NewFilenamePatternOmitter(pattern string) Omitter {
-	return &fileOmitter{filePattern: pattern}
+func NewFilenamePatternOmitter(pattern string) (Omitter, error) {
+	if pattern == "" {
+		return nil, errors.New("pattern for file omitter cannot be empty")
+	}
+	return &fileOmitter{filePattern: pattern}, nil
 }

--- a/pkg/omitter/fileomitter_test.go
+++ b/pkg/omitter/fileomitter_test.go
@@ -40,11 +40,17 @@ func TestFileOmitter(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			omitter := NewFilenamePatternOmitter(tc.pattern)
+			omitter, err := NewFilenamePatternOmitter(tc.pattern)
+			require.NoError(t, err)
 			parts := strings.Split(tc.input, "/")
 			omit, err := omitter.File(parts[len(parts)-1], tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, omit)
 		})
 	}
+}
+
+func TestEmptyPattern(t *testing.T) {
+	_, err := NewFilenamePatternOmitter("")
+	require.Error(t, err)
 }

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -79,7 +79,8 @@ func TestFileWalker(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			fileOmitter := omitter.NewFilenamePatternOmitter("*.log")
+			fileOmitter, err := omitter.NewFilenamePatternOmitter("*.log")
+			require.NoError(t, err)
 			writer := testOutputter(t)
 			reader, err := input.NewFSInput(filepath.Join(tc.inputDir, "mg"))
 			require.NoError(t, err)


### PR DESCRIPTION
Validate the data from the configuration in the `NewFilePatternOmitter()` function instead of the `cli` package.