### PR TITLE
Kubernetes Resource omitter

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -59,6 +59,13 @@ func Run(configPath string, inputPath string, outputPath string) error {
 				return err
 			}
 			omitters = append(omitters, om)
+		case schema.OmitTypeKubernetes:
+			kr := *o.KubernetesResource
+			om, err := omitter.NewKubernetesResourceOmitter(kr.ApiVersion, kr.Kind, kr.Namespaces)
+			if err != nil {
+				return err
+			}
+			omitters = append(omitters, om)
 		}
 	}
 

--- a/pkg/input/filesystem.go
+++ b/pkg/input/filesystem.go
@@ -21,6 +21,10 @@ func (f *fsFile) Permissions() os.FileMode {
 	return f.Mode().Perm()
 }
 
+func (f *fsFile) AbsPath() string {
+	return filepath.Join(f.root.rootDir, f.path)
+}
+
 func (f *fsFile) Scanner() (*bufio.Scanner, func() error, error) {
 	file, err := os.Open(filepath.Join(f.root.Path(), f.path))
 	if err != nil {

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -16,6 +16,8 @@ type File interface {
 	Name() string
 	Permissions() os.FileMode
 	Scanner() (*bufio.Scanner, func() error, error)
+	// AbsPath returns the absolute path to the file
+	AbsPath() string
 }
 
 type DirEntry interface {

--- a/pkg/omitter/kubernetesresource.go
+++ b/pkg/omitter/kubernetesresource.go
@@ -1,0 +1,114 @@
+package omitter
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type kubeMetadata struct {
+	Namespace string `yaml:"namespace" json:"namespace"`
+}
+
+type kubeResource struct {
+	ApiVersion string       `yaml:"apiVersion" json:"apiVersion"`
+	Kind       string       `yaml:"kind" json:"kind"`
+	Metadata   kubeMetadata `yaml:"metadata" json:"metadata"`
+}
+
+type kubeResourceList struct {
+	Items []kubeResource `yaml:"items" json:"items"`
+}
+
+type resourceUnmarshaller func(in []byte, out interface{}) (err error)
+
+type kubernetesResourceOmitter struct {
+	apiVersion   string
+	resourceKind string
+	namespaces   map[string]struct{}
+}
+
+func (k *kubernetesResourceOmitter) File(_, _ string) (bool, error) {
+	return false, nil
+}
+
+func (k *kubernetesResourceOmitter) Contents(path string) (bool, error) {
+	input, err := ioutil.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	var unmarshaller resourceUnmarshaller
+	switch {
+	case strings.HasSuffix(path, ".yml") || strings.HasSuffix(path, ".yaml"):
+		unmarshaller = yaml.Unmarshal
+	case strings.HasSuffix(path, ".json"):
+		unmarshaller = json.Unmarshal
+	default:
+		return false, nil
+	}
+	var resource kubeResource
+	var resourceList kubeResourceList
+	err = unmarshaller(input, &resource)
+	if err != nil {
+		// this means that the input is not a kubernetes resource
+		return false, nil
+	}
+
+	// check if the input was a list type
+	if strings.HasSuffix(resource.Kind, "List") && resource.ApiVersion == "v1" {
+		err = unmarshaller(input, &resourceList)
+		if err != nil {
+			return false, err
+		}
+	} else {
+		resourceList = kubeResourceList{Items: []kubeResource{resource}}
+	}
+
+	if len(resourceList.Items) == 0 {
+		return false, nil
+	}
+
+	var found bool
+	// loop over the resources and if one of them matches the criteria then set the `found` flag.
+	for _, r := range resourceList.Items {
+		// if namespaces are specified then verify that the resource belongs to one of the namespaces
+		if len(k.namespaces) > 0 {
+			if _, ok := k.namespaces[r.Metadata.Namespace]; !ok {
+				continue
+			}
+		}
+
+		// if not of the specified kind then return
+		if k.resourceKind != r.Kind {
+			continue
+		}
+
+		// if apiVersion is specified and does not match resource apiVersion then return
+		if k.apiVersion != "" && k.apiVersion != r.ApiVersion {
+			continue
+		}
+
+		found = true
+		break
+	}
+	return found, nil
+}
+
+func NewKubernetesResourceOmitter(apiVersion, resourceKind *string, namespaces []string) (Omitter, error) {
+	if resourceKind == nil || *resourceKind == "" {
+		return nil, errors.New("no resourceKind specified in omit")
+	}
+	ns := map[string]struct{}{}
+	for _, n := range namespaces {
+		ns[n] = struct{}{}
+	}
+	var version string
+	if apiVersion != nil {
+		version = *apiVersion
+	}
+	return &kubernetesResourceOmitter{apiVersion: version, resourceKind: *resourceKind, namespaces: ns}, nil
+}

--- a/pkg/omitter/kubernetesresource_test.go
+++ b/pkg/omitter/kubernetesresource_test.go
@@ -1,0 +1,241 @@
+package omitter
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKubernetesResourceOmitter(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		apiVersion    string
+		kind          string
+		namespaces    []string
+		expectedError string
+	}{
+		{
+			name:          "all parameters are empty",
+			expectedError: "no resourceKind specified in omit",
+		},
+		{
+			name:       "all parameters are specified",
+			apiVersion: "machine.openshift.io/v1beta1",
+			kind:       "Machine",
+			namespaces: []string{"kube-system", "openshift"},
+		},
+		{
+			name:          "only namespaces is specified",
+			namespaces:    []string{"kube-system", "openshift"},
+			expectedError: "no resourceKind specified in omit",
+		},
+		{
+			name:       "apiVersion and kind is specified but no namespace",
+			apiVersion: "machine.openshift.io/v1beta1",
+			kind:       "Machine",
+		},
+		{
+			name:          "apiVersion but no kind or namespace",
+			apiVersion:    "machine.openshift.io/v1beta1",
+			expectedError: "no resourceKind specified in omit",
+		},
+		{
+			name: "kind but no apiVersion or namespace",
+			kind: "Machine",
+		},
+		{
+			name:          "namespace, apiVersion specified, no kind",
+			apiVersion:    "machine.openshift.io/v1beta1",
+			namespaces:    []string{"kube-system", "oepnshift"},
+			expectedError: "no resourceKind specified in omit",
+		},
+		{
+			name:       "namespace, kind specified, no apiVersion",
+			namespaces: []string{"kube-system", "oepnshift"},
+			kind:       "Machine",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewKubernetesResourceOmitter(&tc.apiVersion, &tc.kind, tc.namespaces)
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestKubernetesResourceOmitter(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		resource   string
+		omit       bool
+		apiVersion string
+		kind       string
+		namespaces []string
+	}{
+		{
+			name: "all match",
+			resource: `apiVersion: v1
+kind: Secret
+metadata:
+    namespace: kube-system
+`,
+			apiVersion: "v1",
+			kind:       "Secret",
+			namespaces: []string{"kube-system", "openshift"},
+			omit:       true,
+		},
+		{
+			name: "namespace match",
+			resource: `apiVersion: v1
+kind: Secret
+metadata:
+    namespace: kube-system
+`,
+			kind:       "Secret",
+			namespaces: []string{"kube-system", "openshift"},
+			omit:       true,
+		},
+		{
+			name: "namespace mismatch",
+			resource: `apiVersion: v1
+kind: Secret
+metadata:
+    namespace: non-secret
+`,
+			kind:       "Secret",
+			namespaces: []string{"kube-system", "openshift"},
+			omit:       false,
+		},
+		{
+			name: "kind mismatch",
+			resource: `apiVersion: v1
+kind: Secret
+metadata:
+    namespace: kube-system
+`,
+			kind:       "ConfigMap",
+			namespaces: []string{"kube-system", "openshift"},
+			omit:       false,
+		},
+		{
+			name: "apiVersion match",
+			resource: `apiVersion: v1
+kind: Secret
+metadata:
+    namespace: kube-system
+`,
+			kind:       "Secret",
+			apiVersion: "v1",
+			omit:       true,
+		},
+		{
+			name: "apiVersion mismatch",
+			resource: `apiVersion: v1
+kind: Secret
+metadata:
+    namespace: kube-system
+`,
+			kind:       "Secret",
+			apiVersion: "v2",
+			omit:       false,
+		},
+		{
+
+			name: "non resource kind",
+			resource: `key1:value1
+key2:value2
+`,
+			kind:       "Secret",
+			apiVersion: "v1",
+			omit:       false,
+		},
+		{
+			name: "resource list all match",
+			resource: `---
+apiVersion: v1
+kind: SecretList
+items:
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+          namespace: kube-system
+          name: first
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+          namespace: kube-system
+          name: second
+`,
+			kind:       "Secret",
+			apiVersion: "v1",
+			omit:       true,
+		},
+		{
+			name: "resource list one match",
+			resource: `---
+apiVersion: v1
+kind: SecretList
+items:
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+          namespace: kube-system
+          name: first
+    - apiVersion: v2
+      kind: Secret
+      metadata:
+          namespace: kube-system
+          name: second
+`,
+			kind:       "Secret",
+			apiVersion: "v1",
+			omit:       true,
+		},
+		{
+			name: "resource list no match",
+			resource: `---
+apiVersion: v1
+kind: SecretList
+items:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+          namespace: kube-system
+          name: first
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+          namespace: kube-system
+          name: second
+`,
+			kind:       "Secret",
+			apiVersion: "v1",
+			omit:       false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			file, err := ioutil.TempFile("", "resource-omit-*.yaml")
+			require.NoError(t, err)
+			defer func(name string) {
+				_ = os.Remove(name)
+			}(file.Name())
+			_, err = file.Write([]byte(tc.resource))
+			require.NoError(t, err)
+			err = file.Close()
+			require.NoError(t, err)
+			require.NoError(t, err)
+			omitter, err := NewKubernetesResourceOmitter(&tc.apiVersion, &tc.kind, tc.namespaces)
+			require.NoError(t, err)
+			omit, err := omitter.Contents(file.Name())
+			require.NoError(t, err)
+			require.Equal(t, tc.omit, omit)
+		})
+	}
+
+}

--- a/pkg/omitter/omitter.go
+++ b/pkg/omitter/omitter.go
@@ -5,5 +5,5 @@ type Omitter interface {
 	// File takes the filename and the path of the file and its return indicates if the file should be included.
 	File(filename, path string) (bool, error)
 	// Contents take the filepath and reads the file to determine if it should be retained or omitted.
-	Contents(contents string) (bool, error)
+	Contents(path string) (bool, error)
 }

--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -70,7 +70,7 @@ func (w *FileWalker) processDir(inputDir input.Directory, outputDirName string) 
 					w.omittedFiles[e.Path()] = struct{}{}
 					break
 				}
-				omit, err = o.Contents(e.Path())
+				omit, err = o.Contents(e.AbsPath())
 				if err != nil {
 					return fmt.Errorf("failed to determine if %s should be omitted based on contents: %w", e.Path(), err)
 				}


### PR DESCRIPTION
The resource omitter reads the contents of a json or yaml file and tries to decode them as a kubernetes resource or a resource list. For a resource list if the input criteria of kind, api version and namespaces match then the omitter indicates this. If for a resource list one of the item matches the criteria then the entire file is omitted.

/assign @tjungblu 