### PR TITLE
Concurrent processing of input directory

### DIFF
--- a/cmd/must-gather-clean/root.go
+++ b/cmd/must-gather-clean/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	goflag "flag"
 	"math/rand"
+	"runtime"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -13,10 +14,11 @@ import (
 
 var (
 	ConfigFile         string
+	DeleteOutputFolder bool
 	InputFolder        string
 	OutputFolder       string
-	DeleteOutputFolder bool
 	ReportingFolder    string
+	WorkerCount        int
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -27,7 +29,7 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		defer klog.Flush()
 
-		err := cli.Run(ConfigFile, InputFolder, OutputFolder, DeleteOutputFolder, ReportingFolder)
+		err := cli.Run(ConfigFile, InputFolder, OutputFolder, DeleteOutputFolder, ReportingFolder, WorkerCount)
 		if err != nil {
 			klog.Exitf("%v\n", err)
 		}
@@ -35,18 +37,16 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&ConfigFile, "config", "c", "", "The path to the obfuscation configuration")
+	flags := rootCmd.Flags()
+	flags.StringVarP(&ConfigFile, "config", "c", "", "The path to the obfuscation configuration")
 	_ = rootCmd.MarkFlagRequired("config")
-
-	rootCmd.Flags().StringVarP(&InputFolder, "input", "i", "", "The directory of the must-gather dump")
+	flags.StringVarP(&InputFolder, "input", "i", "", "The directory of the must-gather dump")
 	_ = rootCmd.MarkFlagRequired("input")
-
-	rootCmd.Flags().StringVarP(&OutputFolder, "output", "o", "", "The directory of the obfuscated output")
+	flags.StringVarP(&OutputFolder, "output", "o", "", "The directory of the obfuscated output")
 	_ = rootCmd.MarkFlagRequired("output")
-
-	rootCmd.Flags().BoolVarP(&DeleteOutputFolder, "overwrite", "d", false, "If the output directory exists, setting this flag will delete the folder and all its contents before cleaning.")
-
-	rootCmd.Flags().StringVarP(&ReportingFolder, "report", "r", ".", "The directory of the reporting output folder, default is the current working directory")
+	flags.BoolVarP(&DeleteOutputFolder, "overwrite", "d", false, "If the output directory exists, setting this flag will delete the folder and all its contents before cleaning.")
+	flags.IntVarP(&WorkerCount, "worker-count", "w", runtime.NumCPU(), "The number of workers for processing")
+	flags.StringVarP(&ReportingFolder, "report", "r", ".", "The directory of the reporting output folder, default is the current working directory")
 
 	fs := goflag.NewFlagSet("", goflag.ExitOnError)
 	klog.InitFlags(fs)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -20,8 +20,10 @@ const (
 	reportFileName = "report.yaml"
 )
 
-func Run(configPath string, inputPath string, outputPath string, deleteOutputFolder bool, reportingFolder string) error {
-
+func Run(configPath string, inputPath string, outputPath string, deleteOutputFolder bool, reportingFolder string, workerCount int) error {
+	if workerCount < 1 {
+		return fmt.Errorf("invalid number of workers specified %d", workerCount)
+	}
 	err := output.EnsureOutputPath(outputPath, deleteOutputFolder)
 	if err != nil {
 		return fmt.Errorf("failed to ensure output folder: %w", err)
@@ -90,15 +92,12 @@ func Run(configPath string, inputPath string, outputPath string, deleteOutputFol
 	if err != nil {
 		return err
 	}
-	walker, err := traversal.NewFileWalker(reader, writer, obfuscators, omitters)
+	walker, err := traversal.NewFileWalker(reader, writer, obfuscators, omitters, workerCount)
 	if err != nil {
 		return err
 	}
 
-	err = walker.Traverse()
-	if err != nil {
-		return fmt.Errorf("failed to generate obfuscated output: %w", err)
-	}
+	walker.Traverse()
 
 	report := walker.GenerateReport()
 

--- a/pkg/obfuscator/keywords.go
+++ b/pkg/obfuscator/keywords.go
@@ -15,6 +15,10 @@ func (o *keywordsObfuscator) FileName(name string) string {
 	return replace(name, o.replacements, o.ReplacementReporter)
 }
 
+func (o *keywordsObfuscator) Contents(contents string) string {
+	return replace(contents, o.replacements, o.ReplacementReporter)
+}
+
 func replace(name string, replacements map[string]string, reporter ReplacementReporter) string {
 	for keyword, replacement := range replacements {
 		if strings.Contains(name, keyword) {
@@ -23,10 +27,6 @@ func replace(name string, replacements map[string]string, reporter ReplacementRe
 		}
 	}
 	return name
-}
-
-func (o *keywordsObfuscator) Contents(contents string) string {
-	return replace(contents, o.replacements, o.ReplacementReporter)
 }
 
 // NewKeywordsObfuscator returns an Obfuscator which replace all occurrences of keys in the map

--- a/pkg/obfuscator/obfuscator.go
+++ b/pkg/obfuscator/obfuscator.go
@@ -2,9 +2,10 @@ package obfuscator
 
 // Obfuscator is the interface which all obfuscators should implement
 type Obfuscator interface {
-	ReplacementReporter
 	// FileName takes a filename as input and return the obfuscated name
 	FileName(string) string
 	// Contents takes string as input and return the obfuscated string
 	Contents(string) string
+	// ReportingResult returns a map of words and their replacements
+	ReportingResult() map[string]string
 }

--- a/pkg/traversal/traversal_test.go
+++ b/pkg/traversal/traversal_test.go
@@ -85,12 +85,12 @@ func TestFileWalker(t *testing.T) {
 			writer := testOutputter(t)
 			reader, err := input.NewFSInput(filepath.Join(tc.inputDir, "mg"))
 			require.NoError(t, err)
-			walker, err := NewFileWalker(reader, writer, []obfuscator.Obfuscator{
-				noopObfuscator{replacements: map[string]string{"secret": "xxxxxx"}},
-			}, []omitter.Omitter{fileOmitter})
+			walker, err := NewFileWalker(reader, writer,
+				[]obfuscator.Obfuscator{
+					noopObfuscator{replacements: map[string]string{"secret": "xxxxxx"}},
+				}, []omitter.Omitter{fileOmitter}, 1)
 			require.NoError(t, err)
-			err = walker.Traverse()
-			require.NoError(t, err)
+			walker.Traverse()
 			contentBytes, err := ioutil.ReadFile(filepath.Join(tc.inputDir, "contents.yaml"))
 			require.NoError(t, err)
 			var contents testContents

--- a/pkg/traversal/worker.go
+++ b/pkg/traversal/worker.go
@@ -1,0 +1,154 @@
+package traversal
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/must-gather-clean/pkg/input"
+	"github.com/openshift/must-gather-clean/pkg/obfuscator"
+	"github.com/openshift/must-gather-clean/pkg/omitter"
+	"github.com/openshift/must-gather-clean/pkg/output"
+)
+
+type fileProcessingError struct {
+	path  string
+	cause error
+}
+
+func (f *fileProcessingError) Error() string {
+	return fmt.Sprintf("failed to process %s: %v", f.path, f.cause)
+}
+
+func (f *fileProcessingError) Cause() error {
+	return f.cause
+}
+
+type workerFile struct {
+	f         input.File
+	outputDir string
+}
+
+type worker struct {
+	id           int
+	obfuscators  []obfuscator.Obfuscator
+	omitters     []omitter.Omitter
+	queue        <-chan workerFile
+	omittedFiles map[string]struct{}
+	writer       output.Outputter
+	errorCh      chan<- error
+}
+
+func newWorker(id int, obfuscators []obfuscator.Obfuscator, omitters []omitter.Omitter, queue <-chan workerFile, writer output.Outputter, errorCh chan<- error) *worker {
+	return &worker{
+		id:           id,
+		obfuscators:  obfuscators,
+		omittedFiles: map[string]struct{}{},
+		omitters:     omitters,
+		queue:        queue,
+		writer:       writer,
+		errorCh:      errorCh,
+	}
+}
+
+func (w *worker) run() {
+	for wf := range w.queue {
+		klog.V(3).Infof("[worker %02d] Processing %s\n", w.id, wf.f.Path())
+
+		// check if the file should be omitted
+		omit, err := w.shouldOmit(wf.f)
+		if err != nil {
+			w.errorCh <- &fileProcessingError{
+				path:  wf.f.Path(),
+				cause: err,
+			}
+			continue
+		}
+
+		// If the file should be omitted then stop processing.
+		if omit {
+			w.omittedFiles[wf.f.Path()] = struct{}{}
+			klog.V(2).Infof("[worker %02d] Omitting file %s", w.id, wf.f.Path())
+			continue
+		}
+
+		// obfuscate the name if required
+		newName := wf.f.Name()
+		for _, o := range w.obfuscators {
+			newName = o.FileName(newName)
+		}
+
+		if wf.f.Name() != newName {
+			klog.V(2).Infof("[worker %02d] Obfuscating file %s as %s", w.id, wf.f.Name(), newName)
+		}
+
+		err = w.obfuscateFile(wf, newName)
+		if err != nil {
+			w.errorCh <- &fileProcessingError{
+				path:  wf.f.Path(),
+				cause: err,
+			}
+		}
+		klog.V(3).Infof("[worker %02d] Finished processing %s\n", w.id, wf.f.Path())
+	}
+}
+
+func (w *worker) shouldOmit(f input.File) (bool, error) {
+	for _, o := range w.omitters {
+		omit, err := o.File(f.Name(), f.Path())
+		if err != nil {
+			return false, err
+		}
+		if omit {
+			return true, nil
+		}
+		omit, err = o.Contents(f.AbsPath())
+		if err != nil {
+			return false, err
+		}
+		if omit {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (w *worker) obfuscateFile(wf workerFile, outputFileName string) error {
+	closeWriter, writer, err := w.writer.Writer(wf.outputDir, outputFileName, wf.f.Permissions())
+	if err != nil {
+		return err
+	}
+	// close the output file when done
+	defer func() {
+		if err := closeWriter(); err != nil {
+			w.errorCh <- &fileProcessingError{
+				path:  wf.f.Path(),
+				cause: err,
+			}
+		}
+	}()
+
+	scanner, closeReader, err := wf.f.Scanner()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := closeReader(); err != nil {
+			w.errorCh <- &fileProcessingError{
+				path:  wf.f.Path(),
+				cause: err,
+			}
+		}
+	}()
+	for scanner.Scan() {
+		contents := scanner.Text()
+		for _, o := range w.obfuscators {
+			contents = o.Contents(contents)
+		}
+		_, err = writer.WriteString(fmt.Sprintf("%s\n", contents))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/traversal/worker_test.go
+++ b/pkg/traversal/worker_test.go
@@ -1,0 +1,144 @@
+package traversal
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/must-gather-clean/pkg/obfuscator"
+	"github.com/openshift/must-gather-clean/pkg/omitter"
+)
+
+type testInputFile struct {
+	relPath string
+	dir     string
+	t       *testing.T
+}
+
+func (t *testInputFile) Path() string {
+	return t.relPath
+}
+
+func (t *testInputFile) Name() string {
+	parts := strings.Split(t.relPath, "/")
+	return parts[len(parts)-1]
+}
+
+func (t *testInputFile) Permissions() os.FileMode {
+	info, err := os.Stat(t.AbsPath())
+	require.NoError(t.t, err)
+	return info.Mode().Perm()
+}
+
+func (t *testInputFile) Scanner() (*bufio.Scanner, func() error, error) {
+	p := t.AbsPath()
+	f, err := os.Open(p)
+	require.NoError(t.t, err)
+	return bufio.NewScanner(f), f.Close, nil
+}
+
+func (t *testInputFile) AbsPath() string {
+	return filepath.Join(t.dir, t.relPath)
+}
+
+type errOmitter struct {
+	contents bool
+	err      error
+}
+
+func (e *errOmitter) File(_, _ string) (bool, error) {
+	if !e.contents {
+		return false, e.err
+	}
+	return false, nil
+}
+
+func (e *errOmitter) Contents(_ string) (bool, error) {
+	if e.contents {
+		return false, e.err
+	}
+	return false, nil
+}
+
+func TestWorker(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		output      string
+		input       string
+		obfuscators []obfuscator.Obfuscator
+		omitter     []omitter.Omitter
+		err         error
+	}{
+		{
+			name:        "simple",
+			input:       "test",
+			output:      "test\n",
+			obfuscators: []obfuscator.Obfuscator{noopObfuscator{}},
+			omitter:     []omitter.Omitter{},
+		},
+		{
+			name:        "error omitters",
+			obfuscators: []obfuscator.Obfuscator{noopObfuscator{}},
+			omitter: []omitter.Omitter{&errOmitter{
+				contents: false,
+				err:      errors.New("omitter error"),
+			}},
+			err: errors.New("omitter error"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "worker-test-*")
+			require.NoError(t, err)
+			defer func() {
+				_ = os.RemoveAll(tempDir)
+			}()
+
+			if tc.input != "" {
+				f, err := os.Create(filepath.Join(tempDir, "test.yaml"))
+				require.NoError(t, err)
+				_, err = f.Write([]byte(tc.input))
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+			}
+
+			workerQueue := make(chan workerFile, 1)
+			errorCh := make(chan error, 1)
+			o := testOutputter(t)
+			w := newWorker(1, tc.obfuscators, tc.omitter, workerQueue, o, errorCh)
+			workerQueue <- workerFile{
+				f: &testInputFile{
+					relPath: "test.yaml",
+					dir:     tempDir,
+					t:       t,
+				},
+			}
+			close(workerQueue)
+			w.run()
+
+			if tc.output != "" {
+				require.Equal(t, tc.output, o.Files["test.yaml"].Contents)
+			}
+
+			if tc.err != nil {
+				timer := time.NewTimer(time.Second)
+				var err error
+				select {
+				case err = <-errorCh:
+				case <-timer.C:
+				}
+				require.NotNil(t, err)
+				require.Equal(t, &fileProcessingError{
+					path:  "test.yaml",
+					cause: tc.err,
+				}, err)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This change modifies the FileWalker to use workers which can process files concurrently. Files are passed to the workers through channels and an error channel returns any errors which might have been encountered when processing a file. When the error channel returns an error the FileWalker immediately exits with the received error..