### PR TITLE
Exclude common non-sensitive IPs from obfuscation

### DIFF
--- a/pkg/obfuscator/ip.go
+++ b/pkg/obfuscator/ip.go
@@ -24,6 +24,11 @@ var (
 	ipv6re      = `([a-f0-9]{0,4}[:]){1,8}[a-f0-9]{1,4}`
 	ipv6Pattern = regexp.MustCompile(ipv6re)
 	ipv4Pattern = regexp.MustCompile(ipv4re)
+	excludedIPs = map[string]struct{}{
+		"127.0.0.1": {},
+		"0.0.0.0":   {},
+		"::1":       {},
+	}
 )
 
 type ipGenerator struct {
@@ -65,6 +70,11 @@ func (o *ipObfuscator) replace(s string) string {
 		ipMatches := pattern.FindAllString(output, -1)
 
 		for _, m := range ipMatches {
+			// if the match is in the exclude-list then do not replace.
+			if _, ok := excludedIPs[m]; ok {
+				continue
+			}
+
 			cleaned := strings.ReplaceAll(m, "-", ".")
 			if ip := net.ParseIP(cleaned); ip != nil {
 				var replacement string

--- a/pkg/obfuscator/ip_test.go
+++ b/pkg/obfuscator/ip_test.go
@@ -94,6 +94,18 @@ func TestIPObfuscatorStatic(t *testing.T) {
 			output: "version: 4.8.12",
 			report: map[string]string{},
 		},
+		{
+			name:   "excluded ipv4 address",
+			input:  "Listening on 0.0.0.0:8080",
+			output: "Listening on 0.0.0.0:8080",
+			report: map[string]string{},
+		},
+		{
+			name:   "excluded ipv6 address",
+			input:  "Listening on [::1]:8080",
+			output: "Listening on [::1]:8080",
+			report: map[string]string{},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			o, err := NewIPObfuscator(schema.ObfuscateReplacementTypeStatic)


### PR DESCRIPTION
Certain IPs like 127.0.0.1 are not sensitive information and should not be obfuscated. They may be necessary for accurate debugging.