### PR TITLE
Fix ambiguous IP obfuscator config

### DIFF
--- a/pkg/obfuscator/ip_test.go
+++ b/pkg/obfuscator/ip_test.go
@@ -321,6 +321,21 @@ func TestIPv6CanonicalKeyConsistent(t *testing.T) {
 					}},
 			}},
 		},
+		{
+			name:   "mixed ipv4 and ipv6 logline",
+			input:  "2021-08-03T09:35:59.743794348Z ::ffff:10.130.0.1 - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 - 2021-08-03T09:35:59.743794348Z ::ffff:10.130.0.1 - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 - 2021-08-03T09:35:59.743794348Z ::ffff:10.130.0.1 - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 - 2021-08-03T09:35:59.743794348Z ::ffff:10.130.0.1 - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 - 2021-08-03T09:35:59.743794348Z ::ffff:10.130.0.1 - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 - 2021-08-03T09:35:59.743794348Z ::ffff:10.130.0.1 - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 -",
+			output: "2021-08-03T09:35:59.743794348Z x-ipv6-0000000001-x:x-ipv4-0000000001-x - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 - 2021-08-03T09:35:59.743794348Z x-ipv6-0000000001-x:x-ipv4-0000000001-x - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 - 2021-08-03T09:35:59.743794348Z x-ipv6-0000000001-x:x-ipv4-0000000001-x - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 - 2021-08-03T09:35:59.743794348Z x-ipv6-0000000001-x:x-ipv4-0000000001-x - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 - 2021-08-03T09:35:59.743794348Z x-ipv6-0000000001-x:x-ipv4-0000000001-x - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 - 2021-08-03T09:35:59.743794348Z x-ipv6-0000000001-x:x-ipv4-0000000001-x - - [03/Aug/2021 09:25:59] \"GET / HTTP/1.1\" 200 -",
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "10.130.0.1", ReplacedWith: "x-ipv4-0000000001-x",
+					Counter: map[string]uint{
+						"10.130.0.1": 6,
+					}},
+				{Canonical: "::FFFF", ReplacedWith: "x-ipv6-0000000001-x",
+					Counter: map[string]uint{
+						"::ffff": 6,
+					}},
+			}},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			o, err := NewIPObfuscator(schema.ObfuscateReplacementTypeConsistent)


### PR DESCRIPTION
A test discovered a pattern the IP obfuscator struggels with:
```
::ffff:10.130.0.1
```

Depending on the order of regular expression selected,
the result can be:

```
::ffff:10.128.0.1
x-ipv6-0000000001-x.128.0.1
```
Or:
```
::ffff:10.128.0.1
::ffff:x-ipv4-0000000001
x-ipv6-0000000001:x-ipv4-0000000001
```

Regular expressions aren't powerful enough to correctly
decide whether the input is `::ffff` or `::ffff:10`.
This problem can however be fixed by replacing ipv4
addresses first.

From go's documentation:

> The iteration order over maps is not specified and is not guaranteed
> to be the same from one iteration to the next.

https://golang.org/ref/spec#For_statements