### PR TITLE
ignore symbolic links during traversal

### DIFF
--- a/pkg/traversal/testfiles/symbolic/symbolic_link
+++ b/pkg/traversal/testfiles/symbolic/symbolic_link
@@ -1,0 +1,1 @@
+some_text.txt

--- a/pkg/traversal/traversal.go
+++ b/pkg/traversal/traversal.go
@@ -2,6 +2,7 @@ package traversal
 
 import (
 	"io/fs"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -54,6 +55,12 @@ func (w *FileWalker) Traverse() {
 		}
 
 		if !dirEntry.IsDir() {
+			// we don't try to obfuscate symbolic links and omit them, as we don't really know where they can point to.
+			if dirEntry.Type()&os.ModeSymlink == os.ModeSymlink {
+				klog.V(3).Infof("Ignoring symbolic link at '%s'\n", path)
+				return nil
+			}
+
 			// the rest of the logic expects the path to be relative to the input dir root, if it fails we assume it is already relative
 			relPath, err := filepath.Rel(w.inputPath, path)
 			if err != nil {


### PR DESCRIPTION
fix for #78 where the symbolic link handling was assuming all links were relative and it broke on absolute paths. 
This PR ignores them and prints a log statement when it is encountered.