### PR TITLE
Skip short strings for canonnical replacements

### DIFF
--- a/pkg/obfuscator/azure_resources.go
+++ b/pkg/obfuscator/azure_resources.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/openshift/must-gather-clean/pkg/schema"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/set"
 )
 
@@ -111,6 +112,11 @@ func (o *azureResourceObfuscator) replace(s string) string {
 
 		for _, canonicalStringToReplace := range canonicalReplacements {
 			if strings.Contains(patternReplacedString, canonicalStringToReplace) {
+				if len(canonicalStringToReplace) < 5 {
+					klog.Warningf("Azure resource obfuscator will skip '%s' because it's too short", canonicalStringToReplace)
+					// we don't want to replace the canonical string if it's too short, because it's probably a trivial string like "0"
+					continue
+				}
 				canonicalToReplacer[canonicalStringToReplace] = currGenerator
 				continue
 			}


### PR DESCRIPTION
If an Azure resource uses a very short name, i.e. 0 or r or n, it will produce a very short canonicalStringToReplace value (in azure_resource.go/replace). These very short strings can cause problems, cause they can render the output file unreadble, since these short strings will cause many false hits.

Example, for a matched ResourceGroup name: 0
Original address: 10.128.8.10
Replaced address: 1x-resourcegroup-0000000001-x.128.8.1x-resourcegroup-0000000001-x