### PR TITLE
Fix: Allow non-root users to run must-gather-clean

### DIFF
--- a/pkg/fsutil/fsutil_unix.go
+++ b/pkg/fsutil/fsutil_unix.go
@@ -4,6 +4,7 @@
 package fsutil
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -15,6 +16,11 @@ func chown(path string, stat fs.FileInfo) error {
 	gid := stat.Sys().(*syscall.Stat_t).Gid
 	err := os.Chown(path, int(uid), int(gid))
 	if err != nil {
+		// Permission denied is expected for non-root users
+		// The file is still created with correct permissions for the current user
+		if errors.Is(err, syscall.EPERM) || errors.Is(err, os.ErrPermission) {
+			return nil
+		}
 		return fmt.Errorf("failed to chown '%s' back to owner (%d, %d): %w", path, uid, gid, err)
 	}
 	return nil


### PR DESCRIPTION
Fixes #111

This commit resolves the issue where non-root users cannot run must-gather-clean due to permission errors when attempting to chown newly created directories.

Changes:
- Modified pkg/fsutil/fsutil_unix.go to gracefully handle EPERM errors
- Added error checking for syscall.EPERM and os.ErrPermission
- Non-root users can now successfully run the tool without chown failures
- Root users continue to preserve original file ownership as before

The fix allows the tool to continue processing when chown operations fail due to insufficient privileges, which is expected behavior for non-root users. Files are still created with appropriate permissions for the current user, and obfuscation completes successfully.

Tested on Linux and macOS with successful obfuscation of sample logs.