### PR TITLE
fix: prevent obfuscation false positives on common words and substrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The following obfuscation types are supported:
 * [Domain name](#domain-name-obfuscation)
 * [Keywords](#keywords)
 * [Regex](#regex)
+* [Azure Resources](#azure-resources-obfuscation)
 
 ### MAC address obfuscation
 
@@ -274,6 +275,40 @@ The resulting filename would literally be: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 This however, is much more useful in the second example where we want to obfuscate that we were using TLSv1.2 as the min version - which would also be replaced as `xxxxxxxxxxxxxxxxxxxxxxx`.
 
 There is currently no support for consistent replacement as in the built-in types, there is a feature upcoming for capture groups and individual replacements thereof.
+
+### Azure Resources obfuscation
+
+The `AzureResources` type detects and obfuscates Azure-specific identifiers that commonly appear in must-gathers from Azure-hosted OpenShift clusters (e.g. ARO, ARO-HCP). It handles:
+
+* **ARM resource paths** — subscription IDs, resource group names, and resource names inside paths like `/subscriptions/{id}/resourceGroups/{name}/providers/...`
+* **Azure identity UUIDs** — `clientId`, `principalId`, `tenantId`, `objectId`, and `appId` values in JSON
+* **Kubernetes Azure labels** — UUIDs in `kubernetes.azure.com/*=UUID` node labels
+
+```
+config:
+  obfuscate:
+  - type: AzureResources
+    replacementType: Consistent
+    target: FileContents
+```
+
+Replacement uses consistent pet names (e.g. `subscription-artistic-walleye`, `resourcegroup-calm-reptile`, `identity-real-walrus`) so that the same identifier always maps to the same replacement across all files.
+
+**Important:** Use `target: FileContents` rather than `target: All` to avoid renaming infrastructure directories like `service/` or `cluster/` that may collide with Azure resource names. To obfuscate Azure domain names (Key Vaults, container registries), use the `Domain` obfuscator:
+
+```
+config:
+  obfuscate:
+  - type: Domain
+    replacementType: Consistent
+    target: All
+    domainNames:
+      - "vault.azure.net"
+      - "azurecr.io"
+  - type: AzureResources
+    replacementType: Consistent
+    target: FileContents
+```
 
 
 #### Chaining obfuscators and side effects

--- a/examples/openshift_default.yaml
+++ b/examples/openshift_default.yaml
@@ -12,9 +12,16 @@ config:
       domainNames:
         - "rhcloud.com"
         - "dev.rhcloud.com"
-    - type: AzureResources
+    - type: Domain
       replacementType: Consistent
       target: All
+      domainNames:
+        - "vault.azure.net"
+        - "azurecr.io"
+        - "blob.core.windows.net"
+    - type: AzureResources
+      replacementType: Consistent
+      target: FileContents
   omit:
     - type: Kubernetes
       kubernetesResource:

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -3,7 +3,10 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/openshift/must-gather-clean/pkg/cleaner"
 	"github.com/openshift/must-gather-clean/pkg/fsutil"
@@ -77,6 +80,11 @@ func Run(configPath string, inputPath string, outputPath string, deleteOutputFol
 	if err != nil {
 		return fmt.Errorf("failed to create obfuscators via config at %s: %w", configPath, err)
 	}
+
+	// Seed Azure Resource Obfuscators with cluster token extracted from
+	// input file names. This enables compound discovery during prescan
+	// even when the dataset contains no ARM paths.
+	seedObfuscatorsFromInputDir(inputPath, obfuscator, prescanObfuscator)
 
 	// this pass allows obfuscators that first need to scan the input to determine what needs to be obfuscated to run before
 	// redactor actually happens. The empty input path signals a dry-run.
@@ -193,4 +201,112 @@ func createObfuscatorsFromConfig(config *schema.SchemaJson) (finalObfuscator *ob
 		obfuscators = append(obfuscators, k)
 	}
 	return obfuscator.NewMultiObfuscator(obfuscators), obfuscator.NewMultiObfuscator(prescanObfuscators), nil
+}
+
+// preferredSeedDirs are the must-gather filesystem subdirectory names most likely
+// to contain files following the <env>-<clusterID>-<type>-<namespace>-<container>
+// naming convention used for cluster token extraction. These are directory names,
+// not semantic keywords — the overlap with genericSkipWords is incidental.
+//
+// "mgmt" is included because ARO-HCP must-gathers contain a separate management
+// cluster log directory whose prefix (e.g. "hcp-underlay-cd-mgmt-1") is entirely
+// different from the service cluster prefix and must be seeded independently.
+var preferredSeedDirs = map[string]struct{}{
+	"service": {},
+	"cluster": {},
+	"mgmt":    {},
+}
+
+// collectFileNames reads non-directory entries from each subdirectory in dirs
+// and returns their base names.
+func collectFileNames(inputPath string, dirs []string) []string {
+	var fileNames []string
+	for _, dir := range dirs {
+		dirPath := filepath.Join(inputPath, dir)
+		entries, err := os.ReadDir(dirPath)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				fileNames = append(fileNames, e.Name())
+			}
+		}
+	}
+	return fileNames
+}
+
+// seedObfuscatorsFromInputDir extracts cluster prefixes from must-gather file
+// names and seeds them into all SeedableObfuscators. Each preferred directory
+// is processed independently so that a must-gather containing both a "service"
+// cluster and a "mgmt" cluster seeds both prefixes even when they share no
+// common prefix. Falls back to all other subdirectories only if no preferred
+// directory yields a valid prefix.
+func seedObfuscatorsFromInputDir(inputPath string, obfuscators ...*obfuscator.MultiObfuscator) {
+	primaryDirs := make([]string, 0, len(preferredSeedDirs))
+	for dir := range preferredSeedDirs {
+		primaryDirs = append(primaryDirs, dir)
+	}
+	sort.Strings(primaryDirs)
+
+	seededAny := false
+	for _, dir := range primaryDirs {
+		fileNames := collectFileNames(inputPath, []string{dir})
+		prefix, token := obfuscator.ExtractClusterInfo(fileNames)
+		if prefix == "" {
+			continue
+		}
+		klog.Infof("discovered cluster prefix %q from input directory %q (token %q)", prefix, dir, token)
+		seedOnePrefix(prefix, token, obfuscators...)
+		seededAny = true
+	}
+
+	if seededAny {
+		return
+	}
+
+	// Fallback: no preferred dir yielded a prefix — try all other subdirs pooled together.
+	entries, err := os.ReadDir(inputPath)
+	if err != nil {
+		return
+	}
+	var fallbackDirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			if _, preferred := preferredSeedDirs[e.Name()]; !preferred {
+				fallbackDirs = append(fallbackDirs, e.Name())
+			}
+		}
+	}
+	fileNames := collectFileNames(inputPath, fallbackDirs)
+	prefix, token := obfuscator.ExtractClusterInfo(fileNames)
+	if prefix == "" {
+		return
+	}
+	klog.Infof("discovered cluster prefix %q from fallback directories (token %q)", prefix, token)
+	seedOnePrefix(prefix, token, obfuscators...)
+}
+
+// seedOnePrefix seeds a single cluster prefix (and optional token) into all
+// SeedableObfuscators, deduplicating by pointer identity so that an obfuscator
+// shared between the final and prescan multi-obfuscators is only seeded once
+// per prefix.
+func seedOnePrefix(prefix, token string, obfuscators ...*obfuscator.MultiObfuscator) {
+	concatenated := strings.ReplaceAll(prefix, "-", "")
+	seen := map[obfuscator.SeedableObfuscator]struct{}{}
+	for _, mo := range obfuscators {
+		for _, o := range mo.SeedableObfuscators() {
+			if _, dup := seen[o]; dup {
+				continue
+			}
+			seen[o] = struct{}{}
+			o.SeedCanonical(prefix)
+			if concatenated != prefix {
+				o.SeedCanonical(concatenated)
+			}
+			if token != "" {
+				o.SetClusterToken(token)
+			}
+		}
+	}
 }

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/openshift/must-gather-clean/pkg/kube"
+	"github.com/openshift/must-gather-clean/pkg/obfuscator"
 	"github.com/openshift/must-gather-clean/pkg/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -199,6 +200,109 @@ config:
 	require.NoError(t, err)
 
 	assert.Equal(t, "some IP 192.167.122.2 that should not to be obfuscated\nand some mac x-mac-0000000001-x\n", string(bytes))
+}
+
+// newSeedableMultiObfuscator builds a MultiObfuscator containing a single
+// AzureResourceObfuscator so we can observe what seedObfuscatorsFromInputDir seeds.
+func newSeedableMultiObfuscator(t *testing.T) *obfuscator.MultiObfuscator {
+	t.Helper()
+	seed := 42
+	tracker := obfuscator.NewSimpleTracker()
+	azureObf, err := obfuscator.NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, tracker, &seed)
+	require.NoError(t, err)
+	return obfuscator.NewMultiObfuscator([]obfuscator.ReportingObfuscator{azureObf})
+}
+
+// writeFiles creates empty files under dir/subdir for each name.
+func writeFiles(t *testing.T, dir, subdir string, names []string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, subdir), 0755))
+	for _, name := range names {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, subdir, name), []byte{}, 0644))
+	}
+}
+
+// TestSeedObfuscatorsFromInputDir_UsesPreferredDirs verifies that when a preferred
+// seed directory ("service" or "cluster") contains valid cluster-named files, its
+// cluster prefix is seeded and the fallback directory is not used.
+func TestSeedObfuscatorsFromInputDir_UsesPreferredDirs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Preferred "service" dir: files yield prefix "dev-qm7v3npl-svc".
+	writeFiles(t, dir, "service", []string{
+		"dev-qm7v3npl-svc-default-pod.jsonl",
+		"dev-qm7v3npl-svc-kube-system-worker.jsonl",
+	})
+	// Fallback dir: different cluster ID — must NOT be seeded.
+	writeFiles(t, dir, "other", []string{
+		"stg-xyz9def2-svc-default-pod.jsonl",
+		"stg-xyz9def2-svc-kube-system-worker.jsonl",
+	})
+
+	mo := newSeedableMultiObfuscator(t)
+	seedObfuscatorsFromInputDir(dir, mo)
+
+	// "dev-qm7v3npl-svc" was seeded from the preferred dir and must be replaced.
+	out := mo.Contents("log line with dev-qm7v3npl-svc in it")
+	assert.NotContains(t, out, "dev-qm7v3npl-svc", "preferred-dir prefix should be obfuscated")
+
+	// The fallback dir's cluster token must NOT have been seeded.
+	out2 := mo.Contents("log line with stg-xyz9def2-svc in it")
+	assert.Contains(t, out2, "xyz9def2", "fallback dir should not be used when preferred dir yields a prefix")
+}
+
+// TestSeedObfuscatorsFromInputDir_FallsBackToOtherDirs verifies that when the
+// preferred seed directories yield no valid cluster prefix, the seeder falls back
+// to all other subdirectories in the input path.
+func TestSeedObfuscatorsFromInputDir_FallsBackToOtherDirs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Preferred "service" dir exists but contains no cluster-named files.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "service"), 0755))
+
+	// Fallback dir has valid cluster-named files yielding prefix "stg-xyz9def2-svc".
+	writeFiles(t, dir, "fallback", []string{
+		"stg-xyz9def2-svc-default-pod.jsonl",
+		"stg-xyz9def2-svc-kube-system-worker.jsonl",
+	})
+
+	mo := newSeedableMultiObfuscator(t)
+	seedObfuscatorsFromInputDir(dir, mo)
+
+	// "stg-xyz9def2-svc" was seeded from the fallback dir and must be replaced.
+	out := mo.Contents("log line with stg-xyz9def2-svc in it")
+	assert.NotContains(t, out, "stg-xyz9def2-svc", "fallback-dir prefix should be obfuscated when preferred dirs yield nothing")
+	assert.NotEqual(t, "log line with stg-xyz9def2-svc in it", out, "output must differ from input — replacement must have occurred")
+}
+
+// TestSeedObfuscatorsFromInputDir_SeedsBothServiceAndMgmt verifies that when both
+// a "service" and "mgmt" preferred directory contain cluster-named files, BOTH
+// prefixes are seeded independently — the mgmt cluster must not be dropped just
+// because the service cluster was found first.
+func TestSeedObfuscatorsFromInputDir_SeedsBothServiceAndMgmt(t *testing.T) {
+	dir := t.TempDir()
+
+	// "service" dir: staging service cluster (tst-northeu-svc-1-*)
+	writeFiles(t, dir, "service", []string{
+		"tst-northeu-svc-1-default-pod.jsonl",
+		"tst-northeu-svc-1-kube-system-worker.jsonl",
+	})
+	// "mgmt" dir: management cluster with entirely different naming scheme
+	writeFiles(t, dir, "mgmt", []string{
+		"hcp-underlay-cd-mgmt-1-default-pod.jsonl",
+		"hcp-underlay-cd-mgmt-1-kube-system-worker.jsonl",
+	})
+
+	mo := newSeedableMultiObfuscator(t)
+	seedObfuscatorsFromInputDir(dir, mo)
+
+	// Service cluster prefix must be obfuscated.
+	out1 := mo.Contents("log line with tst-northeu-svc-1 in it")
+	assert.NotContains(t, out1, "tst-northeu-svc-1", "service cluster prefix must be obfuscated")
+
+	// Management cluster prefix must ALSO be obfuscated.
+	out2 := mo.Contents("log line with hcp-underlay-cd-mgmt-1 in it")
+	assert.NotContains(t, out2, "hcp-underlay-cd-mgmt-1", "management cluster prefix must be obfuscated")
 }
 
 func TestWaterMarkerNotCreatedOnFail(t *testing.T) {

--- a/pkg/obfuscator/azure_resources.go
+++ b/pkg/obfuscator/azure_resources.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/openshift/must-gather-clean/pkg/schema"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/set"
 )
 
@@ -19,6 +18,66 @@ const (
 	staticAzureResourceNameReplacement    = "obfuscated-resource-name"
 	staticAzureSubresourceNameReplacement = "obfuscated-subresource-name"
 )
+
+func isLetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// replaceNotInsideWord is like strings.ReplaceAll but skips matches embedded
+// inside a larger alphabetic token (e.g. "Proxy1" inside "MyProxy1Handler").
+func replaceNotInsideWord(s, old, repl string) (uint, string) {
+	if !strings.Contains(s, old) {
+		return 0, s
+	}
+	var count uint
+	var result strings.Builder
+	result.Grow(len(s))
+	i := 0
+	for {
+		idx := strings.Index(s[i:], old)
+		if idx == -1 {
+			result.WriteString(s[i:])
+			break
+		}
+		absIdx := i + idx
+		endIdx := absIdx + len(old)
+
+		leftIsLetter := absIdx > 0 && isLetter(s[absIdx-1])
+		rightIsLetter := endIdx < len(s) && isLetter(s[endIdx])
+
+		if leftIsLetter || rightIsLetter {
+			result.WriteString(s[i:endIdx])
+			i = endIdx
+		} else {
+			result.WriteString(s[i:absIdx])
+			result.WriteString(repl)
+			count++
+			i = endIdx
+		}
+	}
+	return count, result.String()
+}
+
+// isGenericWord returns true for single-case alphabetic strings like "service" or "GPU"
+// that are too common to safely replace in free text.
+func isGenericWord(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	hasUpper := false
+	hasLower := false
+	for _, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z':
+			hasLower = true
+		case c >= 'A' && c <= 'Z':
+			hasUpper = true
+		default:
+			return false
+		}
+	}
+	return !(hasUpper && hasLower)
+}
 
 var (
 	//     /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVNet/subnets/mySubnet
@@ -105,9 +164,13 @@ func (o *azureResourceObfuscator) replace(s string) string {
 
 		for _, canonicalStringToReplace := range canonicalReplacements {
 			if strings.Contains(patternReplacedString, canonicalStringToReplace) {
+				// Skip strings shorter than 5 characters to avoid false-positive replacements
+				// on trivial values like "0", "vm", or "rg" that appear frequently in
+				// unrelated contexts.
 				if len(canonicalStringToReplace) < 5 {
-					klog.Warningf("Azure resource obfuscator will skip '%s' because it's too short", canonicalStringToReplace)
-					// we don't want to replace the canonical string if it's too short, because it's probably a trivial string like "0"
+					continue
+				}
+				if isGenericWord(canonicalStringToReplace) {
 					continue
 				}
 				canonicalToReplacer[canonicalStringToReplace] = currGenerator
@@ -127,11 +190,16 @@ func (o *azureResourceObfuscator) replace(s string) string {
 		return canonicalStringsList[i] < canonicalStringsList[j]
 	})
 
-	// now do the replace
+	// Replace canonicals in free text, skipping matches embedded inside larger words.
 	for _, canonicalStringToReplace := range canonicalStringsList {
+		// Count matches first (replace-with-self is a counting no-op)
+		count, _ := replaceNotInsideWord(patternReplacedString, canonicalStringToReplace, canonicalStringToReplace)
+		if count == 0 {
+			continue
+		}
 		currGenerator := canonicalToReplacer[canonicalStringToReplace]
-		replacementString := currGenerator.generator.generateReplacement(canonicalStringToReplace, canonicalStringToReplace, 1, o.ReplacementTracker)
-		patternReplacedString = strings.ReplaceAll(patternReplacedString, canonicalStringToReplace, replacementString)
+		replacementString := currGenerator.generator.generateReplacement(canonicalStringToReplace, canonicalStringToReplace, count, o.ReplacementTracker)
+		_, patternReplacedString = replaceNotInsideWord(patternReplacedString, canonicalStringToReplace, replacementString)
 	}
 
 	return patternReplacedString

--- a/pkg/obfuscator/azure_resources.go
+++ b/pkg/obfuscator/azure_resources.go
@@ -17,15 +17,26 @@ const (
 	staticAzureResourceGroupReplacement   = "obfuscated-resourcegroup"
 	staticAzureResourceNameReplacement    = "obfuscated-resource-name"
 	staticAzureSubresourceNameReplacement = "obfuscated-subresource-name"
+	staticAzureIdentityIDReplacement      = "obfuscated-identity-id"
 )
 
 func isLetter(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
-// replaceNotInsideWord is like strings.ReplaceAll but skips matches embedded
-// inside a larger alphabetic token (e.g. "Proxy1" inside "MyProxy1Handler").
-func replaceNotInsideWord(s, old, repl string) (uint, string) {
+// replaceStandalone replaces old with repl only when old stands alone — i.e. the characters
+// immediately before and after it are not letters. Hyphens, dots, slashes, quotes, spaces,
+// and start/end of string are all valid boundaries.
+// Example: replacing "Service" in `"name":"my-Service"` works (boundaries are `"` and `-`),
+// but replacing "Service" in `myServiceHandler` is skipped (boundaries are letters `y` and `H`).
+//
+// skip, if non-nil, is an additional per-match guard: when skip(matchStart, matchEnd) returns
+// true the match is left unchanged. Use this to suppress replacements inside protected ranges
+// (e.g. hyphenated or dotted compound tokens).
+func replaceStandalone(s, old, repl string, skip func(start, end int) bool) (uint, string) {
+	if old == "" {
+		return 0, s
+	}
 	if !strings.Contains(s, old) {
 		return 0, s
 	}
@@ -45,7 +56,7 @@ func replaceNotInsideWord(s, old, repl string) (uint, string) {
 		leftIsLetter := absIdx > 0 && isLetter(s[absIdx-1])
 		rightIsLetter := endIdx < len(s) && isLetter(s[endIdx])
 
-		if leftIsLetter || rightIsLetter {
+		if leftIsLetter || rightIsLetter || (skip != nil && skip(absIdx, endIdx)) {
 			result.WriteString(s[i:endIdx])
 			i = endIdx
 		} else {
@@ -58,35 +69,61 @@ func replaceNotInsideWord(s, old, repl string) (uint, string) {
 	return count, result.String()
 }
 
-// isGenericWord returns true for single-case alphabetic strings like "service" or "GPU"
-// that are too common to safely replace in free text.
-func isGenericWord(s string) bool {
-	if len(s) == 0 {
-		return false
+// countStandalone counts standalone occurrences of old in s without allocating a result string.
+// An occurrence is standalone when neither the byte immediately before nor after it is a letter
+// and skip (if non-nil) returns false for that position.
+func countStandalone(s, old string, skip func(start, end int) bool) uint {
+	if old == "" || !strings.Contains(s, old) {
+		return 0
 	}
-	hasUpper := false
-	hasLower := false
-	for _, c := range s {
-		switch {
-		case c >= 'a' && c <= 'z':
-			hasLower = true
-		case c >= 'A' && c <= 'Z':
-			hasUpper = true
-		default:
-			return false
+	var count uint
+	i := 0
+	for {
+		idx := strings.Index(s[i:], old)
+		if idx == -1 {
+			break
 		}
+		absIdx := i + idx
+		endIdx := absIdx + len(old)
+		leftIsLetter := absIdx > 0 && isLetter(s[absIdx-1])
+		rightIsLetter := endIdx < len(s) && isLetter(s[endIdx])
+		if !leftIsLetter && !rightIsLetter && (skip == nil || !skip(absIdx, endIdx)) {
+			count++
+		}
+		i = endIdx
 	}
-	return !(hasUpper && hasLower)
+	return count
 }
+
+// azureNameChar matches a single character that can appear in an Azure resource name.
+// Excluded: ( ) / whitespace ' " ? ] [ : \
+const azureNameChar = `[^(/\s'"?\]\[:\\)]`
+
+// uuidPattern matches a lowercase UUID (8-4-4-4-12 hex groups).
+const uuidHex = `[0-9a-f]`
+const uuidPattern = uuidHex + `{8}-` + uuidHex + `{4}-` + uuidHex + `{4}-` + uuidHex + `{4}-` + uuidHex + `{12}`
+
+// azureIdentityFieldPattern matches JSON fields whose values are Azure identity
+// UUIDs that should never appear in shared must-gather bundles.
+// Case-insensitivity is scoped to the field name only so that the UUID capture
+// group stays case-sensitive (matching lowercase hex as expected by Azure APIs).
+// Captured groups: (1) field name, (2) UUID value.
+const azureIdentityFieldPattern = `"(?i:(clientId|principalId|tenantId|objectId|appId))"\s*:\s*"(` + uuidPattern + `)"`
+
+// azureK8sLabelPattern matches Kubernetes node labels set by the Azure cloud
+// provider that contain sensitive UUIDs (subscription IDs, VNET GUIDs, etc.).
+// Format: kubernetes.azure.com/LABEL=UUID
+// Captured groups: (1) label name, (2) UUID value.
+const azureK8sLabelPattern = `kubernetes\.azure\.com/([\w-]+)=(` + uuidPattern + `)`
 
 var (
 	//     /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVNet/subnets/mySubnet
 	// Azure resource path pattern
-	azureSubscriptionPattern  = `(?i)/subscriptions/([^(/\s'")]+)`
-	azureResourceGroupPattern = `(?i)/resource[Gg]roups/([^(/\s'")]+)`
-	azureResourcePattern      = `(?i)/providers/([^/]+)/([^/]+)/([^(/\s'")]+)`
-	azureSubresourcePattern   = `(?i)` + azureResourcePattern + `/([^/]+)/([^(/\s'")]+)`
-	azureNodePoolPattern      = `(?i)Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools/([^(/\s'")]+)`
+	azureSubscriptionPattern  = `(?i)/subscriptions/(` + azureNameChar + `+)`
+	azureResourceGroupPattern = `(?i)/resource[Gg]roups/(` + azureNameChar + `+)`
+	azureResourcePattern      = `(?i)/providers/(` + azureNameChar + `+)/(` + azureNameChar + `+)/(` + azureNameChar + `+)`
+	azureSubresourcePattern   = `(?i)` + azureResourcePattern + `/(` + azureNameChar + `+)/(` + azureNameChar + `+)`
+	azureNodePoolPattern      = `(?i)Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools/(` + azureNameChar + `+)`
 )
 
 type partialRegexReplacer struct {
@@ -97,6 +134,11 @@ type partialRegexReplacer struct {
 	lock                  sync.RWMutex
 	generator             *petNameReplacementGenerator
 	canonicalReplacements set.Set[string]
+	// phase1Canonicals tracks canonicals discovered via ARM-path regex (Phase 1).
+	// Unlike canonicalReplacements (which also includes seeded canonicals),
+	// this set is only populated by generateReplacement, never by SeedCanonical.
+	// Used to bypass the isPlainWord guard for private names like "johndoe".
+	phase1Canonicals set.Set[string]
 }
 
 func newPartialRegexReplacer(pattern string, generator *petNameReplacementGenerator, replaceFn func(original string, matches []string, replacer *partialRegexReplacer) string) *partialRegexReplacer {
@@ -107,6 +149,7 @@ func newPartialRegexReplacer(pattern string, generator *petNameReplacementGenera
 
 		generator:             generator,
 		canonicalReplacements: set.Set[string]{},
+		phase1Canonicals:      set.Set[string]{},
 	}
 	ret.repl = func(s string) string {
 		matches := currRegex.FindStringSubmatch(s)
@@ -125,6 +168,7 @@ func (t *partialRegexReplacer) generateReplacement(canonical, original string, c
 	defer t.lock.Unlock()
 
 	t.canonicalReplacements.Insert(canonical)
+	t.phase1Canonicals.Insert(canonical)
 	return t.generator.generateReplacement(canonical, original, count, tracker)
 }
 
@@ -133,6 +177,16 @@ type azureResourceObfuscator struct {
 
 	// we always check all of them because more than one can match a line, but they are evaluated in order because some are more specific than others.
 	orderedPartialRegexReplacers []*partialRegexReplacer
+	resourceReplacer             *partialRegexReplacer
+
+	// clusterMu protects clusterToken and clusterSegmentPattern, which are
+	// written once by SetClusterToken (before workers start) and read
+	// concurrently by Contents.
+	clusterMu             sync.RWMutex
+	clusterToken          string
+	clusterSegmentPattern *regexp.Regexp
+
+	discoveredCompounds sync.Map
 }
 
 func (o *azureResourceObfuscator) Path(s string) string {
@@ -140,9 +194,42 @@ func (o *azureResourceObfuscator) Path(s string) string {
 }
 
 func (o *azureResourceObfuscator) Contents(s string) string {
+	o.clusterMu.RLock()
+	token := o.clusterToken
+	pattern := o.clusterSegmentPattern
+	o.clusterMu.RUnlock()
+
+	if token != "" {
+		for _, compound := range DiscoverSensitiveCompounds(s, token, pattern) {
+			if _, loaded := o.discoveredCompounds.LoadOrStore(compound, struct{}{}); !loaded {
+				o.SeedCanonical(compound)
+			}
+		}
+	}
 	return o.replace(s)
 }
 
+func (o *azureResourceObfuscator) SeedCanonical(canonical string) {
+	replacer := o.resourceReplacer
+	replacer.lock.Lock()
+	replacer.canonicalReplacements.Insert(canonical)
+	replacer.lock.Unlock()
+}
+
+func (o *azureResourceObfuscator) SetClusterToken(token string) {
+	o.clusterMu.Lock()
+	defer o.clusterMu.Unlock()
+	o.clusterToken = token
+	o.clusterSegmentPattern = regexp.MustCompile(`(?:^|-)` + regexp.QuoteMeta(token) + `(?:-|$)`)
+}
+
+// replace obfuscates Azure resource names in s using a two-phase approach:
+//
+//	Phase 1: Match structured ARM paths (/subscriptions/.../providers/...) via
+//	         regex and replace resource names with generated pet names.
+//	Phase 2: Replace any previously-discovered canonical resource names that
+//	         also appear in free text (outside ARM paths), subject to the
+//	         false-positive guards in shouldSkipFreeTextReplacement.
 func (o *azureResourceObfuscator) replace(s string) string {
 	patternReplacedString := s
 
@@ -160,17 +247,21 @@ func (o *azureResourceObfuscator) replace(s string) string {
 	for _, currGenerator := range o.orderedPartialRegexReplacers {
 		currGenerator.lock.RLock()
 		canonicalReplacements := currGenerator.canonicalReplacements.UnsortedList()
+		phase1Snapshot := currGenerator.phase1Canonicals.UnsortedList()
 		currGenerator.lock.RUnlock()
+
+		phase1Set := make(map[string]struct{}, len(phase1Snapshot))
+		for _, c := range phase1Snapshot {
+			phase1Set[c] = struct{}{}
+		}
 
 		for _, canonicalStringToReplace := range canonicalReplacements {
 			if strings.Contains(patternReplacedString, canonicalStringToReplace) {
-				// Skip strings shorter than 5 characters to avoid false-positive replacements
-				// on trivial values like "0", "vm", or "rg" that appear frequently in
-				// unrelated contexts.
-				if len(canonicalStringToReplace) < 5 {
-					continue
-				}
-				if isGenericWord(canonicalStringToReplace) {
+				_, foundViaPhase1 := phase1Set[canonicalStringToReplace]
+				// Gate prevents generic words like "service" from entering free-text
+				// replacement. Phase 1 discoveries bypass the plain-word guard so
+				// private lowercase names (e.g. "johndoe") are fully replaced.
+				if shouldSkipFreeTextReplacement(canonicalStringToReplace, foundViaPhase1) {
 					continue
 				}
 				canonicalToReplacer[canonicalStringToReplace] = currGenerator
@@ -190,16 +281,31 @@ func (o *azureResourceObfuscator) replace(s string) string {
 		return canonicalStringsList[i] < canonicalStringsList[j]
 	})
 
-	// Replace canonicals in free text, skipping matches embedded inside larger words.
+	// Replace canonicals in free text, skipping matches embedded inside larger words
+	// or inside compound tokens.
+	//
+	// For non-hyphenated canonicals (e.g. "myDisk123"), we also guard against
+	// replacement when the canonical is a strict subset of a hyphenated or dotted
+	// compound token (e.g. "myDisk123-handler"). Hyphenated canonicals (e.g.
+	// "dev-wx5r9ktl-svc") are themselves compounds and need no additional guard —
+	// applying compound protection to them would incorrectly block replacement when
+	// they appear as a prefix of a longer hyphenated path like
+	// "dev-wx5r9ktl-svc-kube-system-coredns.jsonl".
 	for _, canonicalStringToReplace := range canonicalStringsList {
-		// Count matches first (replace-with-self is a counting no-op)
-		count, _ := replaceNotInsideWord(patternReplacedString, canonicalStringToReplace, canonicalStringToReplace)
+		var skipFn func(start, end int) bool
+		if !strings.Contains(canonicalStringToReplace, "-") && !strings.Contains(canonicalStringToReplace, ".") {
+			ranges := findProtectedRanges(patternReplacedString)
+			skipFn = func(start, end int) bool {
+				return isProtectedByRanges(ranges, start, end)
+			}
+		}
+		count := countStandalone(patternReplacedString, canonicalStringToReplace, skipFn)
 		if count == 0 {
 			continue
 		}
 		currGenerator := canonicalToReplacer[canonicalStringToReplace]
 		replacementString := currGenerator.generator.generateReplacement(canonicalStringToReplace, canonicalStringToReplace, count, o.ReplacementTracker)
-		_, patternReplacedString = replaceNotInsideWord(patternReplacedString, canonicalStringToReplace, replacementString)
+		_, patternReplacedString = replaceStandalone(patternReplacedString, canonicalStringToReplace, replacementString, skipFn)
 	}
 
 	return patternReplacedString
@@ -222,6 +328,36 @@ func NewAzureResourceObfuscator(replacementType schema.ObfuscateReplacementType,
 	// shared by a couple regexes
 	resourceNameGen := newPetNameReplacementGenerator("resource", staticAzureResourceNameReplacement, petNameGen, replacementType)
 
+	// generatedReplacements tracks already-generated replacement strings so that
+	// a replacement pet name is not itself re-obfuscated by a later regex pass.
+	var generatedReplacements sync.Map
+
+	// Named before adding to the slice so resourceReplacer can reference it directly
+	// without relying on a fragile index into orderedPartialRegexReplacers.
+	azureResourceReplacer := newPartialRegexReplacer(
+		azureResourcePattern,
+		resourceNameGen,
+		func(original string, matches []string, replacer *partialRegexReplacer) string {
+			if len(matches) < 4 {
+				return original
+			}
+
+			providerName := matches[1]
+			resourceType := matches[2]
+			if strings.EqualFold(resourceType, "locations") {
+				return original
+			}
+			if _, ok := generatedReplacements.Load(matches[3]); ok {
+				return original
+			}
+			if semVerPattern.MatchString(matches[3]) {
+				return original
+			}
+			resourceNameReplacement := replacer.generateReplacement(matches[3], matches[3], 1, tracker)
+			generatedReplacements.Store(resourceNameReplacement, struct{}{})
+			return fmt.Sprintf("/providers/%s/%s/%s", providerName, resourceType, resourceNameReplacement)
+		})
+
 	orderedPartialRegexReplacers := []*partialRegexReplacer{
 		newPartialRegexReplacer(
 			azureSubresourcePattern,
@@ -235,22 +371,21 @@ func NewAzureResourceObfuscator(replacementType schema.ObfuscateReplacementType,
 				resourceType := matches[2]
 				resourceName := matches[3]
 				subresourceType := matches[4]
-				subresourceNameReplacement := replacer.generateReplacement(matches[5], matches[5], 1, tracker)
-				return fmt.Sprintf("/providers/%s/%s/%s/%s/%s", providerName, resourceType, resourceName, subresourceType, subresourceNameReplacement)
-			}),
-		newPartialRegexReplacer(
-			azureResourcePattern,
-			resourceNameGen,
-			func(original string, matches []string, replacer *partialRegexReplacer) string {
-				if len(matches) < 4 {
+				subresourceName := matches[5]
+				if _, ok := generatedReplacements.Load(resourceName); ok {
 					return original
 				}
-
-				providerName := matches[1]
-				resourceType := matches[2]
-				resourceNameReplacement := replacer.generateReplacement(matches[3], matches[3], 1, tracker)
-				return fmt.Sprintf("/providers/%s/%s/%s", providerName, resourceType, resourceNameReplacement)
+				if _, ok := generatedReplacements.Load(subresourceName); ok {
+					return original
+				}
+				if semVerPattern.MatchString(subresourceName) {
+					return original
+				}
+				subresourceNameReplacement := replacer.generateReplacement(subresourceName, subresourceName, 1, tracker)
+				generatedReplacements.Store(subresourceNameReplacement, struct{}{})
+				return fmt.Sprintf("/providers/%s/%s/%s/%s/%s", providerName, resourceType, resourceName, subresourceType, subresourceNameReplacement)
 			}),
+		azureResourceReplacer,
 		newPartialRegexReplacer(
 			azureResourceGroupPattern,
 			newPetNameReplacementGenerator("resourcegroup", staticAzureResourceGroupReplacement, petNameGen, replacementType),
@@ -258,8 +393,12 @@ func NewAzureResourceObfuscator(replacementType schema.ObfuscateReplacementType,
 				if len(matches) < 2 {
 					return original
 				}
+				if _, ok := generatedReplacements.Load(matches[1]); ok {
+					return original
+				}
 
 				resourceGroupNameReplacement := replacer.generateReplacement(matches[1], matches[1], 1, tracker)
+				generatedReplacements.Store(resourceGroupNameReplacement, struct{}{})
 				return fmt.Sprintf("/resourcegroups/%s", resourceGroupNameReplacement)
 			}),
 		newPartialRegexReplacer(
@@ -269,8 +408,12 @@ func NewAzureResourceObfuscator(replacementType schema.ObfuscateReplacementType,
 				if len(matches) < 2 {
 					return original
 				}
+				if _, ok := generatedReplacements.Load(matches[1]); ok {
+					return original
+				}
 
 				subscriptionReplacement := replacer.generateReplacement(matches[1], matches[1], 1, tracker)
+				generatedReplacements.Store(subscriptionReplacement, struct{}{})
 				return fmt.Sprintf("/subscriptions/%s", subscriptionReplacement)
 			}),
 		newPartialRegexReplacer(
@@ -280,14 +423,51 @@ func NewAzureResourceObfuscator(replacementType schema.ObfuscateReplacementType,
 				if len(matches) < 2 {
 					return original
 				}
+				if _, ok := generatedReplacements.Load(matches[1]); ok {
+					return original
+				}
 
 				nodePoolReplacement := replacer.generateReplacement(matches[1], matches[1], 1, tracker)
+				generatedReplacements.Store(nodePoolReplacement, struct{}{})
 				return fmt.Sprintf("Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools/%s", nodePoolReplacement)
+			}),
+		newPartialRegexReplacer(
+			azureIdentityFieldPattern,
+			newPetNameReplacementGenerator("identity", staticAzureIdentityIDReplacement, petNameGen, replacementType),
+			func(original string, matches []string, replacer *partialRegexReplacer) string {
+				if len(matches) < 3 {
+					return original
+				}
+				fieldName := matches[1]
+				uuidValue := matches[2]
+				if _, ok := generatedReplacements.Load(uuidValue); ok {
+					return original
+				}
+				replacement := replacer.generateReplacement(uuidValue, uuidValue, 1, tracker)
+				generatedReplacements.Store(replacement, struct{}{})
+				return fmt.Sprintf(`"%s": "%s"`, fieldName, replacement)
+			}),
+		newPartialRegexReplacer(
+			azureK8sLabelPattern,
+			newPetNameReplacementGenerator("identity", staticAzureIdentityIDReplacement, petNameGen, replacementType),
+			func(original string, matches []string, replacer *partialRegexReplacer) string {
+				if len(matches) < 3 {
+					return original
+				}
+				labelName := matches[1]
+				uuidValue := matches[2]
+				if _, ok := generatedReplacements.Load(uuidValue); ok {
+					return original
+				}
+				replacement := replacer.generateReplacement(uuidValue, uuidValue, 1, tracker)
+				generatedReplacements.Store(replacement, struct{}{})
+				return fmt.Sprintf("kubernetes.azure.com/%s=%s", labelName, replacement)
 			}),
 	}
 
 	return &azureResourceObfuscator{
 		ReplacementTracker:           tracker,
 		orderedPartialRegexReplacers: orderedPartialRegexReplacers,
+		resourceReplacer:             azureResourceReplacer,
 	}, nil
 }

--- a/pkg/obfuscator/azure_resources_test.go
+++ b/pkg/obfuscator/azure_resources_test.go
@@ -200,6 +200,306 @@ func TestAzureResourcesObfuscatorContents(t *testing.T) {
 				}},
 			}},
 		},
+		{
+			name: "common word resource names should not corrupt component names",
+			input: []string{
+				// First line discovers "service" as a resource name via Azure path
+				`/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourceGroups/my-rg-123/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service`,
+				// Second line must NOT have "service" replaced in "containerd.service"
+				`"systemd_unit":"containerd.service"`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.ManagedIdentity/userAssignedIdentities/resource-touched-monkey`,
+				// This is the key assertion: "containerd.service" must be preserved
+				`"systemd_unit":"containerd.service"`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "64f0619f-ebc2-4156-9d91-c4c781de7e54", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"64f0619f-ebc2-4156-9d91-c4c781de7e54": uint(1),
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": uint(1),
+				}},
+				{Canonical: "service", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"service": uint(1),
+				}},
+			}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+			require.NoError(t, err)
+			for idx, i := range tc.input {
+				output := o.Contents(i)
+				assert.Equal(t, tc.output[idx], output)
+			}
+			replacementReportsMatch(t, tc.report, o.Report())
+		})
+	}
+}
+
+func TestIsGenericWord(t *testing.T) {
+	for _, tc := range []struct {
+		input    string
+		expected bool
+	}{
+		{"service", true},     // pure lowercase → generic word
+		{"proxy", true},       // pure lowercase → generic word
+		{"network", true},     // pure lowercase → generic word
+		{"GPU", true},         // pure uppercase → generic word
+		{"DNS", true},         // pure uppercase → generic word
+		{"API", true},         // pure uppercase → generic word
+		{"Service", false},    // mixed case → identifier
+		{"MyResource", false}, // mixed case → identifier
+		{"my-service", false}, // has hyphen → identifier
+		{"proxy1", false},     // has digit → identifier
+		{"a-b", false},        // has hyphen → identifier
+		{"", false},           // empty
+		{"node_pool", false},  // has underscore → identifier
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isGenericWord(tc.input))
+		})
+	}
+}
+
+func TestAzureResourceEdgeCases(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		input  []string
+		output []string
+		report ReplacementReport
+	}{
+		{
+			name: "capitalized resource name bypasses isGenericWord and gets replaced globally",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.Compute/disks/Service`,
+				`component: Service is running`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.Compute/disks/resource-touched-monkey`,
+				`component: resource-touched-monkey is running`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": 1,
+				}},
+				// count=2: once in the ARM path, once in free-text (mixed case bypasses isGenericWord)
+				{Canonical: "Service", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"Service": 2,
+				}},
+			}},
+		},
+		{
+			name: "resource name with digit is not a common word and gets replaced",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.Compute/disks/proxy1`,
+				`disk proxy1 is attached`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.Compute/disks/resource-touched-monkey`,
+				`disk resource-touched-monkey is attached`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": 1,
+				}},
+				// count=2: once in ARM path, once in free-text (digit makes it non-generic)
+				{Canonical: "proxy1", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"proxy1": 2,
+				}},
+			}},
+		},
+		{
+			name: "hyphenated resource name is not a common word and gets replaced",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.Compute/disks/my-service`,
+				`disk my-service is attached`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.Compute/disks/resource-touched-monkey`,
+				`disk resource-touched-monkey is attached`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": 1,
+				}},
+				// count=2: once in ARM path, once in free-text (hyphen makes it non-generic)
+				{Canonical: "my-service", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"my-service": 2,
+				}},
+			}},
+		},
+		{
+			name: "lowercase common word resource name is skipped in free-text but replaced in ARM path",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.Network/virtualNetworks/network`,
+				`checking network connectivity`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.Network/virtualNetworks/resource-touched-monkey`,
+				`checking network connectivity`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": 1,
+				}},
+				// count=1: ARM path only — "network" is a generic word (pure lowercase), skipped in free-text
+				{Canonical: "network", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"network": 1,
+				}},
+			}},
+		},
+		{
+			name: "5-char lowercase word (proxy) is common and skipped in free-text",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.Network/applicationGateways/proxy`,
+				`kube-proxy is healthy`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.Network/applicationGateways/resource-touched-monkey`,
+				`kube-proxy is healthy`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": 1,
+				}},
+				// count=1: ARM path only — "proxy" is a generic word (pure lowercase), skipped in free-text
+				{Canonical: "proxy", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"proxy": 1,
+				}},
+			}},
+		},
+		{
+			name: "mixed-case resource name should not replace inside longer tokens",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.Compute/disks/Proxy1`,
+				`MyProxy1Handler started, Proxy1 is ready`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.Compute/disks/resource-touched-monkey`,
+				// "Proxy1" as a standalone word is replaced, but NOT inside "MyProxy1Handler"
+				`MyProxy1Handler started, resource-touched-monkey is ready`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": 1,
+				}},
+				// count=2: once in ARM path, once as standalone word in free-text (NOT inside "MyProxy1Handler")
+				{Canonical: "Proxy1", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"Proxy1": 2,
+				}},
+			}},
+		},
+		{
+			name: "all-uppercase resource name (GPU) is generic and skipped in free-text",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.Compute/virtualMachineScaleSets/GPU`,
+				`GPU utilization is 80%`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.Compute/virtualMachineScaleSets/resource-touched-monkey`,
+				`GPU utilization is 80%`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": 1,
+				}},
+				// count=1: ARM path only — "GPU" is skipped in free-text (len < 5)
+				{Canonical: "GPU", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"GPU": 1,
+				}},
+			}},
+		},
+		{
+			name: "multiple free-text occurrences are counted accurately",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.Compute/disks/MyDisk`,
+				`MyDisk failed, retrying MyDisk, still failing on MyDisk`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.Compute/disks/resource-touched-monkey`,
+				`resource-touched-monkey failed, retrying resource-touched-monkey, still failing on resource-touched-monkey`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": 1,
+				}},
+				// count=4: once in ARM path + three standalone occurrences in free-text
+				{Canonical: "MyDisk", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"MyDisk": 4,
+				}},
+			}},
+		},
+		{
+			name: "URL-encoded resource names are replaced despite %22 digit adjacency",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/basic-hcp-cluster`,
+				`%22api.openshift.com%2Fname%22%3A%22basic-hcp-cluster%22`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/resource-touched-monkey`,
+				`%22api.openshift.com%2Fname%22%3A%22resource-touched-monkey%22`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": 1,
+				}},
+				// count=2: once in ARM path, once in URL-encoded free-text
+				{Canonical: "basic-hcp-cluster", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"basic-hcp-cluster": 2,
+				}},
+			}},
+		},
+		{
+			name: "underscore-prefixed subscription ID is replaced",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.Compute/disks/MyDisk`,
+				`"kubernetes.azure.com/managedby":"sub_aaaa-bbbb"`,
+			},
+			output: []string{
+				`/subscriptions/subscription-feasible-magpie/resourcegroups/resourcegroup-generous-ostrich/providers/Microsoft.Compute/disks/resource-touched-monkey`,
+				`"kubernetes.azure.com/managedby":"sub_subscription-feasible-magpie"`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-feasible-magpie", Counter: map[string]uint{
+					"aaaa-bbbb": 2,
+				}},
+				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
+					"my-rg-123": 1,
+				}},
+				{Canonical: "MyDisk", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"MyDisk": 1,
+				}},
+			}},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))

--- a/pkg/obfuscator/azure_resources_test.go
+++ b/pkg/obfuscator/azure_resources_test.go
@@ -1,6 +1,8 @@
 package obfuscator
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/openshift/must-gather-clean/pkg/schema"
@@ -238,7 +240,7 @@ func TestAzureResourcesObfuscatorContents(t *testing.T) {
 	}
 }
 
-func TestIsGenericWord(t *testing.T) {
+func TestIsPlainWord(t *testing.T) {
 	for _, tc := range []struct {
 		input    string
 		expected bool
@@ -256,9 +258,166 @@ func TestIsGenericWord(t *testing.T) {
 		{"a-b", false},        // has hyphen → identifier
 		{"", false},           // empty
 		{"node_pool", false},  // has underscore → identifier
+		{"a", true},           // single lowercase letter
+		{"Z", true},           // single uppercase letter
+		{"1", false},          // single digit
 	} {
 		t.Run(tc.input, func(t *testing.T) {
-			assert.Equal(t, tc.expected, isGenericWord(tc.input))
+			assert.Equal(t, tc.expected, isPlainWord(tc.input))
+		})
+	}
+}
+
+func TestReplaceStandalone(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		input         string
+		old           string
+		repl          string
+		expectedCount uint
+		expectedOut   string
+	}{
+		{
+			name:          "standalone with spaces",
+			input:         "stg-east-vnet is ready",
+			old:           "stg-east-vnet",
+			repl:          "REPLACED",
+			expectedCount: 1,
+			expectedOut:   "REPLACED is ready",
+		},
+		{
+			name:          "after equals sign",
+			input:         "config=stg-east-vnet ok",
+			old:           "stg-east-vnet",
+			repl:          "REPLACED",
+			expectedCount: 1,
+			expectedOut:   "config=REPLACED ok",
+		},
+		{
+			name:          "at end of string",
+			input:         "use stg-east-vnet",
+			old:           "stg-east-vnet",
+			repl:          "REPLACED",
+			expectedCount: 1,
+			expectedOut:   "use REPLACED",
+		},
+		{
+			name:          "at start of string",
+			input:         "stg-east-vnet starts",
+			old:           "stg-east-vnet",
+			repl:          "REPLACED",
+			expectedCount: 1,
+			expectedOut:   "REPLACED starts",
+		},
+		{
+			name:          "embedded between letters on both sides",
+			input:         "mystg-east-vnetHandler",
+			old:           "stg-east-vnet",
+			repl:          "REPLACED",
+			expectedCount: 0,
+			expectedOut:   "mystg-east-vnetHandler",
+		},
+		{
+			name:          "left neighbor is letter",
+			input:         "xstg-east-vnet ready",
+			old:           "stg-east-vnet",
+			repl:          "REPLACED",
+			expectedCount: 0,
+			expectedOut:   "xstg-east-vnet ready",
+		},
+		{
+			name:          "right neighbor is letter",
+			input:         "use stg-east-vnetz",
+			old:           "stg-east-vnet",
+			repl:          "REPLACED",
+			expectedCount: 0,
+			expectedOut:   "use stg-east-vnetz",
+		},
+		{
+			name:          "multiple standalone occurrences",
+			input:         "two stg-east-vnet refs stg-east-vnet",
+			old:           "stg-east-vnet",
+			repl:          "REPLACED",
+			expectedCount: 2,
+			expectedOut:   "two REPLACED refs REPLACED",
+		},
+		{
+			name:          "hyphen is a boundary so prefix match replaces",
+			input:         "service-foo is ready",
+			old:           "service",
+			repl:          "REPLACED",
+			expectedCount: 1,
+			expectedOut:   "REPLACED-foo is ready",
+		},
+		{
+			name:          "digit neighbor does not block replacement",
+			input:         "%22basic-hcp-cluster%22",
+			old:           "basic-hcp-cluster",
+			repl:          "REPLACED",
+			expectedCount: 1,
+			expectedOut:   "%22REPLACED%22",
+		},
+		{
+			name:          "replacement contains the old string (no infinite loop)",
+			input:         "find abc here",
+			old:           "abc",
+			repl:          "abc-obfuscated",
+			expectedCount: 1,
+			expectedOut:   "find abc-obfuscated here",
+		},
+		{
+			name:          "old is entire string",
+			input:         "abc",
+			old:           "abc",
+			repl:          "XYZ",
+			expectedCount: 1,
+			expectedOut:   "XYZ",
+		},
+		{
+			name:          "consecutive matches with hyphen separator",
+			input:         "abc-abc",
+			old:           "abc",
+			repl:          "XYZ",
+			expectedCount: 2,
+			expectedOut:   "XYZ-XYZ",
+		},
+		{
+			name:          "empty old string returns original",
+			input:         "some text here",
+			old:           "",
+			repl:          "REPLACED",
+			expectedCount: 0,
+			expectedOut:   "some text here",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			count, result := replaceStandalone(tc.input, tc.old, tc.repl, nil)
+			assert.Equal(t, tc.expectedCount, count)
+			assert.Equal(t, tc.expectedOut, result)
+		})
+	}
+}
+
+func TestCountStandalone(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		old      string
+		expected uint
+	}{
+		{name: "standalone with spaces", input: "stg-east-vnet is ready", old: "stg-east-vnet", expected: 1},
+		{name: "at end of string", input: "use stg-east-vnet", old: "stg-east-vnet", expected: 1},
+		{name: "at start of string", input: "stg-east-vnet starts", old: "stg-east-vnet", expected: 1},
+		{name: "multiple occurrences", input: "stg-east-vnet and stg-east-vnet again", old: "stg-east-vnet", expected: 2},
+		{name: "embedded between letters on both sides", input: "mystg-east-vnetHandler", old: "stg-east-vnet", expected: 0},
+		{name: "left neighbor is letter", input: "xstg-east-vnet ready", old: "stg-east-vnet", expected: 0},
+		{name: "right neighbor is letter", input: "use stg-east-vnetz", old: "stg-east-vnet", expected: 0},
+		{name: "not present", input: "nothing here", old: "stg-east-vnet", expected: 0},
+		{name: "empty old", input: "something", old: "", expected: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := countStandalone(tc.input, tc.old, nil)
+			assert.Equal(t, tc.expected, got)
 		})
 	}
 }
@@ -271,7 +430,7 @@ func TestAzureResourceEdgeCases(t *testing.T) {
 		report ReplacementReport
 	}{
 		{
-			name: "capitalized resource name bypasses isGenericWord and gets replaced globally",
+			name: "capitalized resource name bypasses isPlainWord and gets replaced globally",
 			input: []string{
 				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg-123/providers/Microsoft.Compute/disks/Service`,
 				`component: Service is running`,
@@ -287,7 +446,7 @@ func TestAzureResourceEdgeCases(t *testing.T) {
 				{Canonical: "my-rg-123", ReplacedWith: "resourcegroup-generous-ostrich", Counter: map[string]uint{
 					"my-rg-123": 1,
 				}},
-				// count=2: once in the ARM path, once in free-text (mixed case bypasses isGenericWord)
+				// count=2: once in the ARM path, once in free-text (mixed case bypasses isPlainWord)
 				{Canonical: "Service", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
 					"Service": 2,
 				}},
@@ -500,6 +659,95 @@ func TestAzureResourceEdgeCases(t *testing.T) {
 				}},
 			}},
 		},
+		{
+			name: "Azure region preserved in location subresource path",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/resourceGroups/my-rg/providers/Microsoft.RedHatOpenShift/locations/uksouth/hcpOpenShiftVersions/4.19.18`,
+				`cluster is in uksouth region`,
+			},
+			output: []string{
+				`/subscriptions/subscription-generous-ostrich/resourcegroups/resourcegroup-touched-monkey/providers/Microsoft.RedHatOpenShift/locations/uksouth/hcpOpenShiftVersions/4.19.18`,
+				`cluster is in uksouth region`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-generous-ostrich", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "my-rg", ReplacedWith: "resourcegroup-touched-monkey", Counter: map[string]uint{
+					"my-rg": 1,
+				}},
+			}},
+		},
+		{
+			name: "Azure regions preserved regardless of region name",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/providers/Microsoft.RedHatOpenShift/locations/eastus/hcpOpenShiftVersions/4.20.1`,
+				`/subscriptions/aaaa-bbbb/providers/Microsoft.RedHatOpenShift/locations/westeurope/hcpOpenShiftVersions/4.19.0`,
+				`deployed in eastus and westeurope regions`,
+			},
+			output: []string{
+				`/subscriptions/subscription-touched-monkey/providers/Microsoft.RedHatOpenShift/locations/eastus/hcpOpenShiftVersions/4.20.1`,
+				`/subscriptions/subscription-touched-monkey/providers/Microsoft.RedHatOpenShift/locations/westeurope/hcpOpenShiftVersions/4.19.0`,
+				`deployed in eastus and westeurope regions`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-touched-monkey", Counter: map[string]uint{
+					"aaaa-bbbb": 2,
+				}},
+			}},
+		},
+		{
+			name: "Azure region preserved in location-only path",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/providers/Microsoft.RedHatOpenShift/locations/uksouth`,
+			},
+			output: []string{
+				`/subscriptions/subscription-touched-monkey/providers/Microsoft.RedHatOpenShift/locations/uksouth`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-touched-monkey", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+			}},
+		},
+		{
+			name: "common word resource name not replaced outside ARM path",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service`,
+				`the service is running`,
+			},
+			output: []string{
+				`/subscriptions/subscription-generous-ostrich/providers/Microsoft.ManagedIdentity/userAssignedIdentities/resource-touched-monkey`,
+				`the service is running`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-generous-ostrich", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "service", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"service": 1,
+				}},
+			}},
+		},
+		{
+			name: "common word resource name does not corrupt hyphenated compounds",
+			input: []string{
+				`/subscriptions/aaaa-bbbb/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service`,
+				`service-foo is ready and clusters-service is healthy`,
+			},
+			output: []string{
+				`/subscriptions/subscription-generous-ostrich/providers/Microsoft.ManagedIdentity/userAssignedIdentities/resource-touched-monkey`,
+				`service-foo is ready and clusters-service is healthy`,
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "aaaa-bbbb", ReplacedWith: "subscription-generous-ostrich", Counter: map[string]uint{
+					"aaaa-bbbb": 1,
+				}},
+				{Canonical: "service", ReplacedWith: "resource-touched-monkey", Counter: map[string]uint{
+					"service": 1,
+				}},
+			}},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
@@ -509,6 +757,456 @@ func TestAzureResourceEdgeCases(t *testing.T) {
 				assert.Equal(t, tc.output[idx], output)
 			}
 			replacementReportsMatch(t, tc.report, o.Report())
+		})
+	}
+}
+
+func TestAzureResourceSeeding(t *testing.T) {
+	t.Run("seeded canonical is replaced in free text", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		seedable, ok := o.(SeedableObfuscator)
+		require.True(t, ok, "obfuscator must implement SeedableObfuscator")
+
+		seedable.SeedCanonical("dev-wx5r9ktl-svc")
+		output := o.Contents(`cluster dev-wx5r9ktl-svc is running`)
+		require.NotContains(t, output, "dev-wx5r9ktl-svc")
+	})
+
+	t.Run("cluster token discovers compounds during prescan", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		seedable, ok := o.(SeedableObfuscator)
+		require.True(t, ok)
+
+		seedable.SetClusterToken("wx5r9ktl")
+
+		// Prescan pass: Contents() discovers compounds containing the token
+		o.Contents(`consumer_name='hcp-underlay-wx5r9ktl-mgmt-1' active`)
+		o.Contents(`cluster dev-wx5r9ktl-svc is running`)
+
+		// Main pass: discovered compounds are now replaced
+		output1 := o.Contents(`checking hcp-underlay-wx5r9ktl-mgmt-1 status`)
+		require.NotContains(t, output1, "hcp-underlay-wx5r9ktl-mgmt-1",
+			"compound discovered via token should be replaced")
+
+		output2 := o.Contents(`cluster dev-wx5r9ktl-svc is running`)
+		require.NotContains(t, output2, "dev-wx5r9ktl-svc",
+			"compound discovered via token should be replaced")
+	})
+
+	t.Run("concatenated prefix without hyphens is replaced", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		seedable, ok := o.(SeedableObfuscator)
+		require.True(t, ok)
+
+		seedable.SeedCanonical("devwx5r9ktlsvc")
+		output := o.Contents(`k8s:io.cilium.k8s.policy.cluster=devwx5r9ktlsvc,k8s:io.cilium.k8s.policy.serviceaccount=arobit`)
+		require.NotContains(t, output, "devwx5r9ktlsvc",
+			"concatenated cluster prefix should be replaced in Cilium policy labels")
+	})
+
+	t.Run("concatenated plain-word prefix is skipped", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		seedable, ok := o.(SeedableObfuscator)
+		require.True(t, ok)
+
+		seedable.SeedCanonical("stguksouth")
+		output := o.Contents(`cluster stguksouth is running`)
+		require.Contains(t, output, "stguksouth",
+			"plain-word concatenated prefix should be skipped by shouldSkipFreeTextReplacement")
+	})
+
+	t.Run("seeded canonical inside hyphenated compound is not replaced", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		seedable, ok := o.(SeedableObfuscator)
+		require.True(t, ok)
+
+		// "myDisk123" passes shouldSkipFreeTextReplacement (mixed case+digit, length>=5).
+		// When it appears as a prefix in a hyphenated compound it must NOT be replaced,
+		// because replacing just the prefix corrupts the compound name.
+		seedable.SeedCanonical("myDisk123")
+		output := o.Contents("log shows myDisk123-handler is running")
+		assert.Equal(t, "log shows myDisk123-handler is running", output,
+			"canonical that is a strict subset of a compound should not be replaced")
+	})
+
+	t.Run("seeded canonical respects shouldSkipFreeTextReplacement", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		seedable, ok := o.(SeedableObfuscator)
+		require.True(t, ok)
+
+		// "service" is a plain word and should be skipped
+		seedable.SeedCanonical("service")
+		output := o.Contents(`the service is running`)
+		require.Contains(t, output, "service",
+			"plain word canonical should be skipped even when seeded")
+	})
+
+	t.Run("pure-lowercase ARM-path resource name is replaced in free-text field on same line", func(t *testing.T) {
+		// Reproduces the real-world "johndoe" scenario: a developer's personal cluster name
+		// (all lowercase, e.g. "johndoe") appears both inside an ARM path and in a separate
+		// JSON field ("resource_name") on the same log line.
+		// Phase 1 replaces it inside the ARM path. Phase 2 must also replace the standalone
+		// occurrence in the JSON field — the isPlainWord guard must NOT block ARM-path
+		// discoveries, only seeded-only canonicals.
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		line := `{"resource_name":"johndoe","resource_id":"/subscriptions/da057d84-6570-41ea-83f7-f0f61a70542f/resourcegroups/johndoe-net-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/johndoe"}`
+		out := o.Contents(line)
+
+		// ARM path must be replaced (Phase 1):
+		require.NotContains(t, out, "/hcpopenshiftclusters/johndoe",
+			"ARM path resource name must be obfuscated by Phase 1")
+		// Free-text field must also be replaced (Phase 2) — currently failing:
+		require.NotContains(t, out, `"resource_name":"johndoe"`,
+			"pure-lowercase ARM-path resource name must be replaced in free-text JSON fields")
+	})
+
+	t.Run("genericSkipWords are still protected even when found in ARM paths", func(t *testing.T) {
+		// "service" is in genericSkipWords. Even when found as an ARM resource name,
+		// it must NOT be replaced in free-text lines like "the service is running".
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		// Trigger Phase 1 to discover "service" as a resource name
+		o.Contents(`/subscriptions/da057d84-6570-41ea-83f7-f0f61a70542f/resourcegroups/myrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service`)
+		// Free text must still contain "service" untouched
+		out := o.Contents(`the service is running`)
+		require.Contains(t, out, "service",
+			"genericSkipWords must never be replaced in free text, even after Phase 1 discovery")
+	})
+
+	t.Run("clientId UUID field is obfuscated", func(t *testing.T) {
+		// Azure API responses include "clientId" fields that contain MSI (Managed
+		// Service Identity) client UUIDs. These are persistent identifiers tied to
+		// a specific managed identity and must not appear in shared must-gather bundles.
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		line := `{"clientId": "c1d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f", "name": "test"}`
+		out := o.Contents(line)
+		require.NotContains(t, out, "c1d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f",
+			"MSI clientId UUID must be obfuscated")
+	})
+
+	t.Run("principalId UUID field is obfuscated", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		line := `{"principalId": "7f3b1a22-4c9d-4e8f-a1b2-d3e4f5061728"}`
+		out := o.Contents(line)
+		require.NotContains(t, out, "7f3b1a22-4c9d-4e8f-a1b2-d3e4f5061728",
+			"MSI principalId UUID must be obfuscated")
+	})
+
+	t.Run("tenantId UUID field is obfuscated", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		line := `{"tenantId": "a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d"}`
+		out := o.Contents(line)
+		require.NotContains(t, out, "a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d",
+			"tenantId UUID must be obfuscated")
+	})
+
+	t.Run("clientId UUID obfuscated consistently across lines", func(t *testing.T) {
+		// The same UUID appearing in multiple log lines must map to the same
+		// replacement value so correlation across obfuscated lines is preserved.
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		uuid := "c1d2e3f4-5a6b-7c8d-9e0f-1a2b3c4d5e6f"
+		line1 := `{"clientId": "` + uuid + `", "action": "create"}`
+		line2 := `{"clientId": "` + uuid + `", "action": "update"}`
+		out1 := o.Contents(line1)
+		out2 := o.Contents(line2)
+
+		require.NotContains(t, out1, uuid)
+		require.NotContains(t, out2, uuid)
+
+		// Extract the replacement value from line1 and verify line2 uses the same one.
+		re := regexp.MustCompile(`"clientId":\s*"([^"]+)"`)
+		m1 := re.FindStringSubmatch(out1)
+		m2 := re.FindStringSubmatch(out2)
+		require.NotNil(t, m1, "clientId field must be present in obfuscated output")
+		require.NotNil(t, m2, "clientId field must be present in obfuscated output")
+		require.Equal(t, m1[1], m2[1], "same UUID must map to the same replacement across calls")
+	})
+
+	t.Run("objectId UUID field is obfuscated", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+		line := `{"objectId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}`
+		out := o.Contents(line)
+		assert.NotContains(t, out, "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			"objectId UUID must be obfuscated")
+	})
+
+	t.Run("appId UUID field is obfuscated", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+		line := `{"appId": "12345678-abcd-ef01-2345-678901234567"}`
+		out := o.Contents(line)
+		assert.NotContains(t, out, "12345678-abcd-ef01-2345-678901234567",
+			"appId UUID must be obfuscated")
+	})
+
+	t.Run("kubernetes.azure.com label UUIDs are obfuscated", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+		line := `kubernetes.azure.com/network-subscription=aabbccdd-1122-3344-5566-778899001122,kubernetes.azure.com/podnetwork-subscription=aabbccdd-1122-3344-5566-778899001122`
+		out := o.Contents(line)
+		assert.NotContains(t, out, "aabbccdd-1122-3344-5566-778899001122",
+			"subscription UUID in k8s label must be obfuscated")
+		assert.Contains(t, out, "kubernetes.azure.com/network-subscription=",
+			"label key must be preserved")
+		assert.Contains(t, out, "kubernetes.azure.com/podnetwork-subscription=",
+			"label key must be preserved")
+	})
+
+	t.Run("kubernetes.azure.com client-id and vnetguid labels are obfuscated", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+		line := `kubernetes.azure.com/kubelet-identity-client-id=00112233-aabb-ccdd-eeff-445566778899,kubernetes.azure.com/nodenetwork-vnetguid=99887766-5544-3322-1100-ffeeddccbbaa`
+		out := o.Contents(line)
+		assert.NotContains(t, out, "00112233-aabb-ccdd-eeff-445566778899",
+			"client-id UUID must be obfuscated")
+		assert.NotContains(t, out, "99887766-5544-3322-1100-ffeeddccbbaa",
+			"vnetguid UUID must be obfuscated")
+	})
+
+	t.Run("kubernetes.azure.com label UUIDs obfuscated consistently", func(t *testing.T) {
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+		uuid := "aabbccdd-1122-3344-5566-778899001122"
+		line1 := `kubernetes.azure.com/network-subscription=` + uuid
+		line2 := `kubernetes.azure.com/podnetwork-subscription=` + uuid
+		out1 := o.Contents(line1)
+		out2 := o.Contents(line2)
+		re := regexp.MustCompile(`kubernetes\.azure\.com/[\w-]+=(.+)`)
+		m1 := re.FindStringSubmatch(out1)
+		m2 := re.FindStringSubmatch(out2)
+		require.NotNil(t, m1)
+		require.NotNil(t, m2)
+		require.Equal(t, m1[1], m2[1], "same UUID must map to same replacement")
+	})
+
+	t.Run("knownInfraComponents are still protected even when found in ARM paths", func(t *testing.T) {
+		// "disk-csi-driver" is in knownInfraComponents. Even when discovered as an
+		// ARM resource name (foundViaPhase1=true), it must NOT be replaced in free text
+		// because it is also a standard OpenShift component name.
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		// Phase 1: discover "disk-csi-driver" as a resource name
+		o.Contents(`/subscriptions/da057d84-6570-41ea-83f7-f0f61a70542f/resourcegroups/myrg/providers/Microsoft.Compute/disks/disk-csi-driver`)
+		// Free text must still contain "disk-csi-driver" untouched
+		out := o.Contents(`the disk-csi-driver pod is running`)
+		require.Contains(t, out, "disk-csi-driver",
+			"knownInfraComponents must not be replaced in free text, even after Phase 1 ARM-path discovery")
+	})
+}
+
+func TestAzureResourceRegexBoundaries(t *testing.T) {
+	t.Run("trailing colon causes sensitive cluster name to leak in free text", func(t *testing.T) {
+		// Real pattern from staging must-gather (clusters-service-server.jsonl):
+		// Azure 404 error puts a colon right after the cluster name in the ARM path.
+		// With the old regex the canonical becomes "basic-cluster:" (with colon),
+		// so bare "basic-cluster" elsewhere goes un-obfuscated — sensitive data leaks.
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		// Line 1: real error format — colon follows the cluster name directly
+		o.Contents(`/subscriptions/99399281-aaaa-bbbb-cccc-b2645bbbdb93/resourceGroups/rg-cluster-nsg-subnet-reuse-vr9hbh/providers/Microsoft.RedHatOpenShift/HCPOpenShiftClusters/basic-cluster: The resource 'HCPOpenShiftClusters/basic-cluster' under resource group 'rg-cluster-nsg-subnet-reuse-vr9hbh' was not found.`)
+
+		// Line 2: the same cluster name appears in URL-encoded free text — MUST be obfuscated
+		output := o.Contents(`%22api.openshift.com%2Fname%22%3A%22basic-cluster%22`)
+		require.NotContains(t, output, "basic-cluster",
+			"sensitive cluster name leaked because trailing colon was captured as part of the canonical")
+	})
+
+	t.Run("trailing bracket causes sensitive deny assignment ID to leak in free text", func(t *testing.T) {
+		// Real pattern from staging must-gather (clusters-service-server.jsonl):
+		// Deny assignment creation log puts the ARM path with ] directly after
+		// the subresource UUID. With the old regex the canonical becomes
+		// "b32549d3-f2e7-5c12-9306-7d6265fa0e73]" (with bracket), so bare UUID
+		// elsewhere goes un-obfuscated.
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		// Line 1: real log format — bracket follows the deny assignment UUID
+		o.Contents(`/subscriptions/99399281-aaaa-bbbb-cccc-b2645bbbdb93/resourceGroups/disabled-image-registry-n7b4j2--managed/providers/Microsoft.Authorization/denyAssignments/b32549d3-f2e7-5c12-9306-7d6265fa0e73] created successfully for resource group`)
+
+		// Line 2: the same UUID appears without bracket — MUST be obfuscated
+		output := o.Contents(`checking deny assignment b32549d3-f2e7-5c12-9306-7d6265fa0e73 status`)
+		require.NotContains(t, output, "b32549d3-f2e7-5c12-9306-7d6265fa0e73",
+			"sensitive deny assignment ID leaked because trailing bracket was captured as part of the canonical")
+	})
+
+	t.Run("escaped newline causes vnet name plus error body to become the canonical", func(t *testing.T) {
+		// Real pattern from staging must-gather (aro-hcp-backend.jsonl line 255413):
+		// Azure 429 error response is JSON-escaped into a log line. The literal
+		// characters \n appear after the vnet name. With the old regex the canonical
+		// becomes "customer-vnet\n---\nRESPONSE 429..." instead of "customer-vnet",
+		// so the real vnet name goes un-obfuscated — sensitive data leaks.
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		// Line 1: real log format — JSON-escaped \n follows the vnet name
+		o.Contents(`/subscriptions/99399281-aaaa-bbbb-cccc-b2645bbbdb93/resourceGroups/oidc-wi-hfhmjt/providers/Microsoft.Network/virtualNetworks/customer-vnet\n--------------------------------------------------------------------------------\nRESPONSE 429: 429 Too Many Requests\nERROR CODE UNAVAILABLE\n--`)
+
+		// The canonical in the report must be just "customer-vnet", not the
+		// garbage string "customer-vnet\n---\nRESPONSE..."
+		report := o.Report()
+		for _, r := range report.Replacements {
+			require.NotContains(t, r.Canonical, `\n`,
+				"report canonical contains escaped newline garbage — regex captured past the resource name")
+		}
+
+		// Line 2: the same vnet name appears cleanly elsewhere — MUST be obfuscated
+		output := o.Contents(`"vnetID":"/subscriptions/99399281-aaaa-bbbb-cccc-b2645bbbdb93/resourceGroups/oidc-wi-hfhmjt/providers/Microsoft.Network/virtualNetworks/customer-vnet/subnets/customer-subnet-1"`)
+		require.NotContains(t, output, "customer-vnet",
+			"sensitive vnet name leaked because escaped newline was captured as part of the canonical")
+	})
+
+	t.Run("colon after cluster name eats punctuation and breaks formatting", func(t *testing.T) {
+		// Real pattern: when the colon is captured, the replacement removes
+		// the colon from the output, turning "basic-cluster: The resource"
+		// into "resource-pet-name The resource" — broken punctuation.
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		output := o.Contents(`/subscriptions/99399281-aaaa-bbbb-cccc-b2645bbbdb93/resourceGroups/rg-nsg-reuse-vr9hbh/providers/Microsoft.RedHatOpenShift/HCPOpenShiftClusters/basic-cluster: The resource was not found.`)
+
+		require.Contains(t, output, ": The resource was not found.",
+			"colon after cluster name was swallowed into the replacement")
+	})
+
+	t.Run("bracket after deny assignment ID in log preserved", func(t *testing.T) {
+		// Real pattern: the bracket must be preserved as log formatting,
+		// not captured as part of the deny assignment UUID.
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		output := o.Contents(`/subscriptions/99399281-aaaa-bbbb-cccc-b2645bbbdb93/resourceGroups/my-rg--managed/providers/Microsoft.Authorization/denyAssignments/b32549d3-f2e7-5c12-9306-7d6265fa0e73] created successfully`)
+
+		require.Contains(t, output, "] created successfully",
+			"trailing bracket was swallowed into the deny assignment ID capture")
+		require.NotContains(t, output, "b32549d3-f2e7-5c12-9306-7d6265fa0e73",
+			"deny assignment ID was not obfuscated")
+	})
+
+	t.Run("generated pet name is not re-obfuscated by a later regex pass", func(t *testing.T) {
+		// When a resource group name is replaced with a pet name like
+		// "resourcegroup-generous-ostrich", a later regex pass could match
+		// that pet name as a new resource name. The generatedReplacements
+		// guard prevents this double-obfuscation.
+		o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+		require.NoError(t, err)
+
+		// Process two ARM paths — the first generates replacements, the
+		// second must not re-obfuscate those replacements.
+		output1 := o.Contents(`/subscriptions/aaaa-bbbb/resourceGroups/my-rg/providers/Microsoft.Compute/disks/my-disk`)
+		output2 := o.Contents(`/subscriptions/aaaa-bbbb/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet`)
+
+		// Extract the subscription and RG replacements from the first output
+		// and verify the second output reuses the same replacements
+		// (not re-obfuscated into different pet names).
+		require.NotContains(t, output1, "aaaa-bbbb")
+		require.NotContains(t, output1, "my-rg")
+		require.NotContains(t, output2, "aaaa-bbbb")
+		require.NotContains(t, output2, "my-rg")
+
+		// Both must produce the same subscription/RG prefix — extract and compare
+		prefix1 := output1[:strings.Index(output1, "/providers/")]
+		prefix2 := output2[:strings.Index(output2, "/providers/")]
+		require.Equal(t, prefix1, prefix2,
+			"subscription/RG replacements changed between calls — pet names may have been re-obfuscated")
+	})
+}
+
+func TestAzureResourceObfuscator_Path(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		seedCanonicals []string
+		armPaths       []string
+		inputPath      string
+		expectContains []string
+		expectMissing  []string
+	}{
+		{
+			name:           "service folder preserved",
+			inputPath:      "service/foo.jsonl",
+			expectContains: []string{"service/foo.jsonl"},
+		},
+		{
+			name:           "cluster folder preserved",
+			inputPath:      "cluster/events.json",
+			expectContains: []string{"cluster/events.json"},
+		},
+		{
+			name:           "system folder preserved",
+			inputPath:      "system/logs.json",
+			expectContains: []string{"system/logs.json"},
+		},
+		{
+			name: "discovered resource name in path is obfuscated",
+			armPaths: []string{
+				"/subscriptions/aaaa-bbbb/resourceGroups/my-rg/providers/Microsoft.Compute/disks/my-cluster",
+			},
+			inputPath:     "service/my-cluster-events.jsonl",
+			expectMissing: []string{"my-cluster"},
+		},
+		{
+			name:           "seeded canonical in path is obfuscated",
+			seedCanonicals: []string{"dev-wx5r9ktl-svc"},
+			inputPath:      "service/dev-wx5r9ktl-svc-kube-system-coredns.jsonl",
+			expectMissing:  []string{"dev-wx5r9ktl-svc"},
+		},
+		{
+			name:           "seeded canonical preserves service folder name",
+			seedCanonicals: []string{"dev-wx5r9ktl-svc"},
+			inputPath:      "service/dev-wx5r9ktl-svc-clusters-service-clusters-service-server.jsonl",
+			expectContains: []string{"service/"},
+			expectMissing:  []string{"dev-wx5r9ktl-svc"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			o, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+			require.NoError(t, err)
+
+			// Seed canonicals if specified
+			if seedable, ok := o.(SeedableObfuscator); ok {
+				for _, c := range tc.seedCanonicals {
+					seedable.SeedCanonical(c)
+				}
+			}
+
+			// Process ARM paths to discover canonicals
+			for _, arm := range tc.armPaths {
+				o.Contents(arm)
+			}
+
+			result := o.Path(tc.inputPath)
+
+			for _, want := range tc.expectContains {
+				require.Contains(t, result, want)
+			}
+			for _, notWant := range tc.expectMissing {
+				require.NotContains(t, result, notWant)
+			}
 		})
 	}
 }

--- a/pkg/obfuscator/ip.go
+++ b/pkg/obfuscator/ip.go
@@ -26,12 +26,24 @@ var (
 	ipv6re      = `(([a-f0-9]{0,4}[:]){1,8}([0-9a-fA-F]{1,4}|::)+)`
 	ipv6Pattern = regexp.MustCompile(ipv6re)
 	ipv4Pattern = regexp.MustCompile(ipv4re)
+	// 0.0.0.0 is not listed here because the IPv4 regex requires first octets
+	// to start with [1-9], so it can never match.
 	excludedIPs = map[string]struct{}{
-		"127.0.0.1": {},
-		"0.0.0.0":   {},
-		"::1":       {},
+		"::1": {},
 	}
+	loopbackCIDR *net.IPNet
 )
+
+func init() {
+	// loopbackCIDR covers the entire 127.0.0.0/8 range — all loopback addresses
+	// (not just 127.0.0.1) are excluded because they are non-routable and never
+	// contain sensitive information.
+	var err error
+	_, loopbackCIDR, err = net.ParseCIDR("127.0.0.0/8")
+	if err != nil {
+		panic("failed to parse loopback CIDR: " + err.Error())
+	}
+}
 
 type ipObfuscator struct {
 	ReplacementTracker
@@ -55,18 +67,37 @@ func (o *ipObfuscator) replace(s string) string {
 	output := s
 
 	for _, r := range o.replacements {
-		ipMatches := r.pattern.FindAllString(output, -1)
-		for _, m := range ipMatches {
-			// if the match is in the exclude-list then do not replace.
-			if _, ok := excludedIPs[m]; ok {
+		// Collect matches with boundary context before modifying the string.
+		type ipMatch struct {
+			value         string
+			followedByLetter bool
+		}
+		var matches []ipMatch
+		for _, loc := range r.pattern.FindAllStringIndex(output, -1) {
+			m := output[loc[0]:loc[1]]
+			followed := loc[1] < len(output) && isLetter(output[loc[1]])
+			matches = append(matches, ipMatch{value: m, followedByLetter: followed})
+		}
+
+		for _, match := range matches {
+			if _, ok := excludedIPs[match.value]; ok {
 				continue
 			}
 
-			cleaned := strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(m, "_", "."), "-", "."))
+			// For hyphenated/underscored IP forms (e.g. 10-0-187-218), skip matches
+			// where the next character is a letter — that indicates a version suffix
+			// in a pod name (e.g. 1-26-8-4dxrb) rather than a real IP address.
+			if strings.ContainsAny(match.value, "-_") && match.followedByLetter {
+				continue
+			}
+
+			cleaned := strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(match.value, "_", "."), "-", "."))
 			if ip := net.ParseIP(cleaned); ip != nil {
-				replacement := r.generator.generateReplacement(cleaned, m, 1, o.ReplacementTracker)
-				// TODO(thomas): should just replace that one matching occurrence instead of all
-				output = strings.ReplaceAll(output, m, replacement)
+				if loopbackCIDR.Contains(ip) {
+					continue
+				}
+				replacement := r.generator.generateReplacement(cleaned, match.value, 1, o.ReplacementTracker)
+				output = strings.ReplaceAll(output, match.value, replacement)
 			}
 		}
 	}

--- a/pkg/obfuscator/ip_test.go
+++ b/pkg/obfuscator/ip_test.go
@@ -126,6 +126,18 @@ func TestIPObfuscatorStatic(t *testing.T) {
 			report: map[string]string{},
 		},
 		{
+			name:   "version in pod name not treated as IP",
+			input:  "pod asm-istio-base-crd-installer-1-26-8-4dxrb is running",
+			output: "pod asm-istio-base-crd-installer-1-26-8-4dxrb is running",
+			report: map[string]string{},
+		},
+		{
+			name:   "real hyphenated IP still replaced",
+			input:  "etcd-ip-10-0-187-218.ec2.internal",
+			output: "etcd-ip-xxx.xxx.xxx.xxx.ec2.internal",
+			report: map[string]string{"10-0-187-218": obfuscatedStaticIPv4},
+		},
+		{
 			name:   "excluded ipv4 address",
 			input:  "Listening on 0.0.0.0:8080",
 			output: "Listening on 0.0.0.0:8080",
@@ -144,6 +156,24 @@ func TestIPObfuscatorStatic(t *testing.T) {
 			report: map[string]string{
 				"172.30.0.10": obfuscatedStaticIPv4,
 			},
+		},
+		{
+			name:   "loopback 127.0.0.6 is excluded",
+			input:  `"request_remote_ip":"127.0.0.6:33353"`,
+			output: `"request_remote_ip":"127.0.0.6:33353"`,
+			report: map[string]string{},
+		},
+		{
+			name:   "loopback 127.0.0.2 is excluded",
+			input:  `connected to 127.0.0.2:8080`,
+			output: `connected to 127.0.0.2:8080`,
+			report: map[string]string{},
+		},
+		{
+			name:   "loopback 127.255.255.255 is excluded",
+			input:  `bound to 127.255.255.255`,
+			output: `bound to 127.255.255.255`,
+			report: map[string]string{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/obfuscator/keywords.go
+++ b/pkg/obfuscator/keywords.go
@@ -1,41 +1,65 @@
 package obfuscator
 
 import (
-	"strings"
+	"regexp"
+	"sort"
 )
 
 type keywordsObfuscator struct {
 	ReplacementTracker
 	replacements map[string]string
+	patterns     map[string]*regexp.Regexp
+	orderedKeys  []string
 }
 
 func (o *keywordsObfuscator) Path(name string) string {
-	return replace(name, o.replacements, o.ReplacementTracker)
+	return o.replace(name)
 }
 
 func (o *keywordsObfuscator) Contents(contents string) string {
-	return replace(contents, o.replacements, o.ReplacementTracker)
+	return o.replace(contents)
 }
 
-func replace(name string, replacements map[string]string, reporter ReplacementTracker) string {
-	for keyword, replacement := range replacements {
-		if strings.Contains(name, keyword) {
-			cnt := uint(strings.Count(name, keyword))
-			_ = reporter.GenerateIfAbsent(keyword, keyword, cnt, func() string {
+func (o *keywordsObfuscator) replace(name string) string {
+	for _, keyword := range o.orderedKeys {
+		replacement := o.replacements[keyword]
+		pattern := o.patterns[keyword]
+		matches := pattern.FindAllString(name, -1)
+		if len(matches) > 0 {
+			cnt := uint(len(matches))
+			// Track the replacement; return value is unused because keywords use a fixed mapping.
+			_ = o.GenerateIfAbsent(keyword, keyword, cnt, func() string {
 				return replacement
 			})
-			name = strings.Replace(name, keyword, replacement, -1)
+			name = pattern.ReplaceAllString(name, replacement)
 		}
 	}
 	return name
 }
 
-// NewKeywordsObfuscator returns an Obfuscator which replace all occurrences of keys in the map
-// passed to it with the value of the key.
+// NewKeywordsObfuscator returns an Obfuscator that replaces word-boundary (\b) matches
+// of each key with its corresponding value. Go's \b treats underscores and digits as
+// word characters, so "server" won't match inside "grpc_server" or "server01", but
+// dots and hyphens are boundaries, so it will match inside "containerd.service".
 func NewKeywordsObfuscator(replacements map[string]string) ReportingObfuscator {
 	tracker := NewSimpleTrackerMap(replacements)
+	patterns := make(map[string]*regexp.Regexp, len(replacements))
+	// Longest-first so longer matches win over overlapping shorter ones.
+	orderedKeys := make([]string, 0, len(replacements))
+	for keyword := range replacements {
+		patterns[keyword] = regexp.MustCompile(`\b` + regexp.QuoteMeta(keyword) + `\b`)
+		orderedKeys = append(orderedKeys, keyword)
+	}
+	sort.Slice(orderedKeys, func(i, j int) bool {
+		if len(orderedKeys[i]) != len(orderedKeys[j]) {
+			return len(orderedKeys[i]) > len(orderedKeys[j])
+		}
+		return orderedKeys[i] < orderedKeys[j]
+	})
 	return &keywordsObfuscator{
 		ReplacementTracker: tracker,
 		replacements:       replacements,
+		patterns:           patterns,
+		orderedKeys:        orderedKeys,
 	}
 }

--- a/pkg/obfuscator/keywords.go
+++ b/pkg/obfuscator/keywords.go
@@ -3,6 +3,8 @@ package obfuscator
 import (
 	"regexp"
 	"sort"
+
+	"k8s.io/klog/v2"
 )
 
 type keywordsObfuscator struct {
@@ -24,29 +26,45 @@ func (o *keywordsObfuscator) replace(name string) string {
 	for _, keyword := range o.orderedKeys {
 		replacement := o.replacements[keyword]
 		pattern := o.patterns[keyword]
-		matches := pattern.FindAllString(name, -1)
-		if len(matches) > 0 {
-			cnt := uint(len(matches))
-			// Track the replacement; return value is unused because keywords use a fixed mapping.
-			_ = o.GenerateIfAbsent(keyword, keyword, cnt, func() string {
+		allMatches := pattern.FindAllStringIndex(name, -1)
+		if len(allMatches) == 0 {
+			continue
+		}
+
+		ranges := findProtectedRanges(name)
+		var unprotectedCount uint
+		// Replace right-to-left so indices stay valid.
+		for i := len(allMatches) - 1; i >= 0; i-- {
+			loc := allMatches[i]
+			if isProtectedByRanges(ranges, loc[0], loc[1]) {
+				continue
+			}
+			unprotectedCount++
+			name = name[:loc[0]] + replacement + name[loc[1]:]
+		}
+
+		if unprotectedCount > 0 {
+			_ = o.GenerateIfAbsent(keyword, keyword, unprotectedCount, func() string {
 				return replacement
 			})
-			name = pattern.ReplaceAllString(name, replacement)
 		}
 	}
 	return name
 }
 
 // NewKeywordsObfuscator returns an Obfuscator that replaces word-boundary (\b) matches
-// of each key with its corresponding value. Go's \b treats underscores and digits as
-// word characters, so "server" won't match inside "grpc_server" or "server01", but
-// dots and hyphens are boundaries, so it will match inside "containerd.service".
+// of each key with its corresponding value. Keywords in the generic skip list are excluded
+// at construction time. Matches inside protected compounds (dotted like containerd.service,
+// hyphenated like kube-apiserver) are also skipped at replacement time via findProtectedRanges.
 func NewKeywordsObfuscator(replacements map[string]string) ReportingObfuscator {
 	tracker := NewSimpleTrackerMap(replacements)
 	patterns := make(map[string]*regexp.Regexp, len(replacements))
-	// Longest-first so longer matches win over overlapping shorter ones.
 	orderedKeys := make([]string, 0, len(replacements))
 	for keyword := range replacements {
+		if isSkipListWord(keyword) {
+			klog.Warningf("keyword %q is too generic and will be skipped to avoid false positives", keyword)
+			continue
+		}
 		patterns[keyword] = regexp.MustCompile(`\b` + regexp.QuoteMeta(keyword) + `\b`)
 		orderedKeys = append(orderedKeys, keyword)
 	}

--- a/pkg/obfuscator/keywords_test.go
+++ b/pkg/obfuscator/keywords_test.go
@@ -80,6 +80,134 @@ func TestNewKeywordsObfuscator(t *testing.T) {
 					}},
 			}},
 		},
+		{
+			name: "should not match substrings within words",
+			replacements: map[string]string{
+				"server": "redacted",
+			},
+			// "maestro-server" matches: hyphen is a word boundary
+			// "grpc_server" does NOT match: underscore is a word character (\w), no boundary
+			// "containerd.service" does NOT match: "server" is not present
+			// "observability" does NOT match: no "server" substring
+			input:          "maestro-server grpc_server containerd.service observability",
+			expectedOutput: "maestro-redacted grpc_server containerd.service observability",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "server", ReplacedWith: "redacted",
+					Counter: map[string]uint{
+						"server": 1,
+					}},
+			}},
+		},
+		{
+			name: "should not match keyword as substring of longer word",
+			replacements: map[string]string{
+				"dns": "redacted",
+			},
+			input:          "coredns is running on the dns server",
+			expectedOutput: "coredns is running on the redacted server",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "dns", ReplacedWith: "redacted",
+					Counter: map[string]uint{
+						"dns": 1,
+					}},
+			}},
+		},
+		{
+			name:           "dot is a word boundary: service matches in containerd.service",
+			replacements:   map[string]string{"service": "REDACTED"},
+			input:          `"systemd_unit":"containerd.service"`,
+			expectedOutput: `"systemd_unit":"containerd.REDACTED"`,
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "service", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"service": 1,
+					}},
+			}},
+		},
+		{
+			name:           "slash is a word boundary: network matches in /var/log/network.log",
+			replacements:   map[string]string{"network": "REDACTED"},
+			input:          "/var/log/network.log",
+			expectedOutput: "/var/log/REDACTED.log",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "network", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"network": 1,
+					}},
+			}},
+		},
+		{
+			name:           "hyphen is a word boundary: agent matches in node-agent-xyz",
+			replacements:   map[string]string{"agent": "REDACTED"},
+			input:          "node-agent-xyz",
+			expectedOutput: "node-REDACTED-xyz",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "agent", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"agent": 1,
+					}},
+			}},
+		},
+		{
+			name:           "underscore is NOT a word boundary: agent does not match in node_agent_xyz",
+			replacements:   map[string]string{"agent": "REDACTED"},
+			input:          "node_agent_xyz",
+			expectedOutput: "node_agent_xyz",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "agent", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"agent": 0,
+					}},
+			}},
+		},
+		{
+			name:           "camelCase: no boundary between lowercase and uppercase",
+			replacements:   map[string]string{"server": "REDACTED"},
+			input:          "myServer handles requests",
+			expectedOutput: "myServer handles requests",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "server", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"server": 0,
+					}},
+			}},
+		},
+		{
+			name:           "numeric suffix prevents match: node vs node01",
+			replacements:   map[string]string{"node": "REDACTED"},
+			input:          "node01 is healthy, node is not",
+			expectedOutput: "node01 is healthy, REDACTED is not",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "node", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"node": 1,
+					}},
+			}},
+		},
+		{
+			name:           "colon is a word boundary: proxy matches after colon",
+			replacements:   map[string]string{"proxy": "REDACTED"},
+			input:          `"component":"kube-proxy"`,
+			expectedOutput: `"component":"kube-REDACTED"`,
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "proxy", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"proxy": 1,
+					}},
+			}},
+		},
+		{
+			name:           "equals sign is a word boundary",
+			replacements:   map[string]string{"admin": "REDACTED"},
+			input:          "user=admin role=viewer",
+			expectedOutput: "user=REDACTED role=viewer",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "admin", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"admin": 1,
+					}},
+			}},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			o := NewKeywordsObfuscator(tc.replacements)

--- a/pkg/obfuscator/keywords_test.go
+++ b/pkg/obfuscator/keywords_test.go
@@ -13,6 +13,7 @@ func TestNewKeywordsObfuscator(t *testing.T) {
 		input          string
 		expectedOutput string
 		expectLegend   ReplacementReport
+		usePath        bool
 	}{
 		{
 			name: "basic",
@@ -81,20 +82,17 @@ func TestNewKeywordsObfuscator(t *testing.T) {
 			}},
 		},
 		{
-			name: "should not match substrings within words",
+			name: "should not match inside protected compounds or non-boundary positions",
 			replacements: map[string]string{
-				"server": "redacted",
+				"maestro": "redacted",
 			},
-			// "maestro-server" matches: hyphen is a word boundary
-			// "grpc_server" does NOT match: underscore is a word character (\w), no boundary
-			// "containerd.service" does NOT match: "server" is not present
-			// "observability" does NOT match: no "server" substring
-			input:          "maestro-server grpc_server containerd.service observability",
-			expectedOutput: "maestro-redacted grpc_server containerd.service observability",
+			// "maestro-server" is protected (\w+-server), "grpc_maestro" has no \b boundary
+			input:          "maestro-server grpc_maestro maestro is running",
+			expectedOutput: "maestro-server grpc_maestro redacted is running",
 			expectLegend: ReplacementReport{[]Replacement{
-				{Canonical: "server", ReplacedWith: "redacted",
+				{Canonical: "maestro", ReplacedWith: "redacted",
 					Counter: map[string]uint{
-						"server": 1,
+						"maestro": 1,
 					}},
 			}},
 		},
@@ -113,46 +111,34 @@ func TestNewKeywordsObfuscator(t *testing.T) {
 			}},
 		},
 		{
-			name:           "dot is a word boundary: service matches in containerd.service",
+			name:           "generic skip word: service is not replaced anywhere",
 			replacements:   map[string]string{"service": "REDACTED"},
-			input:          `"systemd_unit":"containerd.service"`,
-			expectedOutput: `"systemd_unit":"containerd.REDACTED"`,
+			input:          `"systemd_unit":"containerd.service" and service is running`,
+			expectedOutput: `"systemd_unit":"containerd.service" and service is running`,
 			expectLegend: ReplacementReport{[]Replacement{
 				{Canonical: "service", ReplacedWith: "REDACTED",
 					Counter: map[string]uint{
-						"service": 1,
+						"service": 0,
 					}},
 			}},
 		},
 		{
-			name:           "slash is a word boundary: network matches in /var/log/network.log",
+			name:           "generic skip word: network is not replaced",
 			replacements:   map[string]string{"network": "REDACTED"},
 			input:          "/var/log/network.log",
-			expectedOutput: "/var/log/REDACTED.log",
+			expectedOutput: "/var/log/network.log",
 			expectLegend: ReplacementReport{[]Replacement{
 				{Canonical: "network", ReplacedWith: "REDACTED",
 					Counter: map[string]uint{
-						"network": 1,
+						"network": 0,
 					}},
 			}},
 		},
 		{
-			name:           "hyphen is a word boundary: agent matches in node-agent-xyz",
+			name:           "generic skip word: agent is not replaced",
 			replacements:   map[string]string{"agent": "REDACTED"},
 			input:          "node-agent-xyz",
-			expectedOutput: "node-REDACTED-xyz",
-			expectLegend: ReplacementReport{[]Replacement{
-				{Canonical: "agent", ReplacedWith: "REDACTED",
-					Counter: map[string]uint{
-						"agent": 1,
-					}},
-			}},
-		},
-		{
-			name:           "underscore is NOT a word boundary: agent does not match in node_agent_xyz",
-			replacements:   map[string]string{"agent": "REDACTED"},
-			input:          "node_agent_xyz",
-			expectedOutput: "node_agent_xyz",
+			expectedOutput: "node-agent-xyz",
 			expectLegend: ReplacementReport{[]Replacement{
 				{Canonical: "agent", ReplacedWith: "REDACTED",
 					Counter: map[string]uint{
@@ -161,57 +147,165 @@ func TestNewKeywordsObfuscator(t *testing.T) {
 			}},
 		},
 		{
+			name:           "underscore is NOT a word boundary: maestro does not match in node_maestro_xyz",
+			replacements:   map[string]string{"maestro": "REDACTED"},
+			input:          "node_maestro_xyz",
+			expectedOutput: "node_maestro_xyz",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "maestro", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"maestro": 0,
+					}},
+			}},
+		},
+		{
 			name:           "camelCase: no boundary between lowercase and uppercase",
-			replacements:   map[string]string{"server": "REDACTED"},
-			input:          "myServer handles requests",
-			expectedOutput: "myServer handles requests",
+			replacements:   map[string]string{"maestro": "REDACTED"},
+			input:          "myMaestro handles requests",
+			expectedOutput: "myMaestro handles requests",
 			expectLegend: ReplacementReport{[]Replacement{
-				{Canonical: "server", ReplacedWith: "REDACTED",
+				{Canonical: "maestro", ReplacedWith: "REDACTED",
 					Counter: map[string]uint{
-						"server": 0,
+						"maestro": 0,
 					}},
 			}},
 		},
 		{
-			name:           "numeric suffix prevents match: node vs node01",
-			replacements:   map[string]string{"node": "REDACTED"},
-			input:          "node01 is healthy, node is not",
-			expectedOutput: "node01 is healthy, REDACTED is not",
+			name:           "numeric suffix prevents match",
+			replacements:   map[string]string{"maestro": "REDACTED"},
+			input:          "maestro01 is healthy, maestro is not",
+			expectedOutput: "maestro01 is healthy, REDACTED is not",
 			expectLegend: ReplacementReport{[]Replacement{
-				{Canonical: "node", ReplacedWith: "REDACTED",
+				{Canonical: "maestro", ReplacedWith: "REDACTED",
 					Counter: map[string]uint{
-						"node": 1,
+						"maestro": 1,
 					}},
 			}},
 		},
 		{
-			name:           "colon is a word boundary: proxy matches after colon",
+			name:           "generic skip word: proxy is not replaced",
 			replacements:   map[string]string{"proxy": "REDACTED"},
 			input:          `"component":"kube-proxy"`,
-			expectedOutput: `"component":"kube-REDACTED"`,
+			expectedOutput: `"component":"kube-proxy"`,
 			expectLegend: ReplacementReport{[]Replacement{
 				{Canonical: "proxy", ReplacedWith: "REDACTED",
 					Counter: map[string]uint{
-						"proxy": 1,
+						"proxy": 0,
 					}},
 			}},
 		},
 		{
 			name:           "equals sign is a word boundary",
-			replacements:   map[string]string{"admin": "REDACTED"},
-			input:          "user=admin role=viewer",
-			expectedOutput: "user=REDACTED role=viewer",
+			replacements:   map[string]string{"stg-east-ch": "REDACTED"},
+			input:          "cluster=stg-east-ch env=staging",
+			expectedOutput: "cluster=REDACTED env=staging",
 			expectLegend: ReplacementReport{[]Replacement{
-				{Canonical: "admin", ReplacedWith: "REDACTED",
+				{Canonical: "stg-east-ch", ReplacedWith: "REDACTED",
 					Counter: map[string]uint{
-						"admin": 1,
+						"stg-east-ch": 1,
+					}},
+			}},
+		},
+		{
+			name:           "protected context: systemd unit not broken",
+			replacements:   map[string]string{"crio": "REDACTED"},
+			input:          `started crio.service successfully, crio is ready`,
+			expectedOutput: `started crio.service successfully, REDACTED is ready`,
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "crio", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"crio": 1,
+					}},
+			}},
+		},
+		{
+			name:           "protected context: multiple systemd units not broken",
+			replacements:   map[string]string{"kubelet": "REDACTED"},
+			input:          `kubelet.service started, kubelet is ready, NetworkManager.service active`,
+			expectedOutput: `kubelet.service started, REDACTED is ready, NetworkManager.service active`,
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "kubelet", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"kubelet": 1,
+					}},
+			}},
+		},
+		{
+			name:           "protected context: kube-compound not broken",
+			replacements:   map[string]string{"apiserver": "REDACTED"},
+			input:          `kube-apiserver is running, apiserver logs`,
+			expectedOutput: `kube-apiserver is running, REDACTED logs`,
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "apiserver", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"apiserver": 1,
+					}},
+			}},
+		},
+		{
+			name:           "Path: keyword is replaced in file paths",
+			replacements:   map[string]string{"stg-east-ch": "REDACTED"},
+			input:          "/logs/stg-east-ch/pods.log",
+			expectedOutput: "/logs/REDACTED/pods.log",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "stg-east-ch", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"stg-east-ch": 1,
+					}},
+			}},
+			usePath: true,
+		},
+		{
+			name: "overlapping keywords: longest match wins",
+			replacements: map[string]string{
+				"east":        "R1",
+				"stg-east-ch": "R2",
+			},
+			input:          "cluster stg-east-ch region east done",
+			expectedOutput: "cluster R2 region R1 done",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "east", ReplacedWith: "R1",
+					Counter: map[string]uint{
+						"east": 1,
+					}},
+				{Canonical: "stg-east-ch", ReplacedWith: "R2",
+					Counter: map[string]uint{
+						"stg-east-ch": 1,
+					}},
+			}},
+		},
+		{
+			name:           "keyword with dot: QuoteMeta prevents regex injection",
+			replacements:   map[string]string{"v1.2": "REDACTED"},
+			input:          "version v1.2 is old, v1x2 is not",
+			expectedOutput: "version REDACTED is old, v1x2 is not",
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "v1.2", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"v1.2": 1,
+					}},
+			}},
+		},
+		{
+			name:           "compound keyword still matches",
+			replacements:   map[string]string{"kube-proxy": "REDACTED"},
+			input:          `component "kube-proxy" started`,
+			expectedOutput: `component "REDACTED" started`,
+			expectLegend: ReplacementReport{[]Replacement{
+				{Canonical: "kube-proxy", ReplacedWith: "REDACTED",
+					Counter: map[string]uint{
+						"kube-proxy": 1,
 					}},
 			}},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			o := NewKeywordsObfuscator(tc.replacements)
-			require.Equal(t, tc.expectedOutput, o.Contents(tc.input))
+			if tc.usePath {
+				require.Equal(t, tc.expectedOutput, o.Path(tc.input))
+			} else {
+				require.Equal(t, tc.expectedOutput, o.Contents(tc.input))
+			}
 			replacementReportsMatch(t, tc.expectLegend, o.Report())
 		})
 	}

--- a/pkg/obfuscator/multi_obfuscator.go
+++ b/pkg/obfuscator/multi_obfuscator.go
@@ -42,3 +42,29 @@ func (m *MultiObfuscator) ReportPerObfuscator() []ReplacementReport {
 func NewMultiObfuscator(o []ReportingObfuscator) *MultiObfuscator {
 	return &MultiObfuscator{obfuscators: o}
 }
+
+// SeedableObfuscators returns all obfuscators that implement SeedableObfuscator.
+func (m *MultiObfuscator) SeedableObfuscators() []SeedableObfuscator {
+	var result []SeedableObfuscator
+	for _, o := range m.obfuscators {
+		if s, ok := unwrapSeedable(o); ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// unwrapSeedable checks if o implements SeedableObfuscator, unwrapping
+// any number of targetObfuscator layers to find it.
+func unwrapSeedable(o ReportingObfuscator) (SeedableObfuscator, bool) {
+	for {
+		if s, ok := o.(SeedableObfuscator); ok {
+			return s, true
+		}
+		t, ok := o.(*targetObfuscator)
+		if !ok {
+			return nil, false
+		}
+		o = t.obfuscator
+	}
+}

--- a/pkg/obfuscator/multi_obfuscator_test.go
+++ b/pkg/obfuscator/multi_obfuscator_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openshift/must-gather-clean/pkg/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 )
 
 type splitObfuscator struct {
@@ -102,4 +105,39 @@ func TestMultiObfuscationReportMulti(t *testing.T) {
 		{"this must be split thrice": "must be split thrice"},
 		{"must be split thrice": "be split thrice"},
 		{"be split thrice": "split thrice"}}, reportsAsMap)
+}
+
+func TestSeedableObfuscators_DirectSeedable(t *testing.T) {
+	azureObs, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+	require.NoError(t, err)
+	mo := NewMultiObfuscator([]ReportingObfuscator{azureObs})
+	seedable := mo.SeedableObfuscators()
+	require.Len(t, seedable, 1)
+}
+
+func TestSeedableObfuscators_SingleWrapped(t *testing.T) {
+	azureObs, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+	require.NoError(t, err)
+	wrapped := NewTargetObfuscator(schema.ObfuscateTargetFileContents, azureObs)
+	mo := NewMultiObfuscator([]ReportingObfuscator{wrapped})
+	seedable := mo.SeedableObfuscators()
+	require.Len(t, seedable, 1)
+}
+
+func TestSeedableObfuscators_DoubleWrapped(t *testing.T) {
+	azureObs, err := NewAzureResourceObfuscator(schema.ObfuscateReplacementTypeConsistent, NewSimpleTracker(), ptr.To(1))
+	require.NoError(t, err)
+	wrapped := NewTargetObfuscator(schema.ObfuscateTargetFileContents, azureObs)
+	doubleWrapped := NewTargetObfuscator(schema.ObfuscateTargetAll, wrapped)
+	mo := NewMultiObfuscator([]ReportingObfuscator{doubleWrapped})
+	seedable := mo.SeedableObfuscators()
+	require.Len(t, seedable, 1)
+}
+
+func TestSeedableObfuscators_NonSeedableSkipped(t *testing.T) {
+	mo := NewMultiObfuscator([]ReportingObfuscator{
+		&splitObfuscator{tracker: NewSimpleTracker()},
+	})
+	seedable := mo.SeedableObfuscators()
+	require.Len(t, seedable, 0)
 }

--- a/pkg/obfuscator/obfuscator.go
+++ b/pkg/obfuscator/obfuscator.go
@@ -13,3 +13,11 @@ type ReportingObfuscator interface {
 	// Report returns a map of words and their Replacements
 	Report() ReplacementReport
 }
+
+// SeedableObfuscator can accept pre-known sensitive identifiers that were
+// not discovered from ARM paths.
+type SeedableObfuscator interface {
+	ReportingObfuscator
+	SeedCanonical(canonical string)
+	SetClusterToken(token string)
+}

--- a/pkg/obfuscator/protected.go
+++ b/pkg/obfuscator/protected.go
@@ -1,0 +1,171 @@
+package obfuscator
+
+import (
+	"regexp"
+)
+
+// semVerPattern matches semantic version strings like 4.19.18 or v1.2.3-rc1
+// that should never be treated as Azure resource names.
+var semVerPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+`)
+
+// protectedPatterns match compound tokens (hyphenated like "kube-apiserver",
+// dotted like "containerd.service") where a keyword match should be suppressed.
+//
+// A match is only protected when it is a STRICT SUBSET of the compound — i.e.,
+// the compound is strictly larger than the match. This means:
+//   - keyword "proxy" does NOT match inside "kube-proxy" (strict subset, protected)
+//   - keyword "kube-proxy" DOES match "kube-proxy" exactly (not a strict subset)
+//
+// Without this, replacing "service" would corrupt "containerd.service" into
+// "containerd.REDACTED", and replacing "proxy" would break "kube-proxy".
+var protectedPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\w+(?:-\w+)+`),
+	regexp.MustCompile(`\w+(?:\.\w+)+`),
+}
+
+// genericSkipWords are single, common English words that frequently appear as
+// Azure resource names (e.g., a managed identity named "service") but also
+// appear pervasively in logs and config files. They are excluded from BOTH
+// free-text Azure replacement (via shouldSkipFreeTextReplacement) and keyword
+// obfuscation (via isSkipListWord in NewKeywordsObfuscator).
+//
+// Add a word here when it is:
+//  1. A single, unhyphenated, common English/infrastructure term, AND
+//  2. Replacing it in free text would cause widespread false positives.
+//
+// Do NOT add compound names here — those belong in knownInfraComponents.
+var genericSkipWords = map[string]struct{}{
+	"service":    {},
+	"cluster":    {},
+	"network":    {},
+	"default":    {},
+	"proxy":      {},
+	"agent":      {},
+	"node":       {},
+	"server":     {},
+	"worker":     {},
+	"master":     {},
+	"system":     {},
+	"controller": {},
+	"monitor":    {},
+	"gateway":    {},
+	"storage":    {},
+	"admin":      {},
+	"ingress":    {},
+}
+
+// knownInfraComponents are hyphenated compound names used as both Azure managed
+// identity resource names and standard OpenShift component names. They must
+// not be replaced in free text.
+var knownInfraComponents = map[string]struct{}{
+	"cloud-controller-manager": {},
+	"cloud-network-config":     {},
+	"cluster-api-azure":        {},
+	"control-plane":            {},
+	"disk-csi-driver":          {},
+	"file-csi-driver":          {},
+	"image-registry":           {},
+}
+
+// isSkipListWord returns true if s exactly matches one of the hardcoded common words
+// like "service", "proxy", "agent". Only exact matches — "my-service" is NOT in the
+// list and would still be replaced.
+//
+// This is intentionally a different mechanism from isPlainWord: isSkipListWord catches
+// known specific terms regardless of structure, while isPlainWord catches the broader
+// class of letters-only single-case strings. The two guards are complementary, not redundant.
+func isSkipListWord(s string) bool {
+	_, ok := genericSkipWords[s]
+	return ok
+}
+
+// isPlainWord returns true if s is a simple word with no hyphens, digits, or mixed case —
+// e.g. "service", "GPU". These are too generic to safely replace in free text.
+func isPlainWord(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	hasUpper := false
+	hasLower := false
+	for _, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z':
+			hasLower = true
+		case c >= 'A' && c <= 'Z':
+			hasUpper = true
+		default:
+			return false
+		}
+	}
+	return !(hasUpper && hasLower)
+}
+
+// shouldSkipFreeTextReplacement returns true if s should NOT be replaced
+// outside of structured Azure ARM paths. This prevents false positives
+// when Azure resource names happen to collide with common English words,
+// infrastructure component names, or version strings.
+//
+// foundViaPhase1 is true when s was discovered by the ARM-path regex (Phase 1)
+// rather than only being seeded externally. Phase 1 discoveries bypass the plain-word
+// guard so that pure-lowercase private names like "johndoe" are still replaced in
+// free-text fields (e.g. "resource_name":"johndoe") after their ARM path is replaced.
+// The genericSkipWords guard is never bypassed: words like "service" must never be
+// replaced in free text regardless of how they were discovered.
+//
+// Guards (checked in order):
+//  1. Too short (< 5 chars): Azure resource names under 5 characters (e.g., "vm",
+//     "rg", "GPU", "0") are too ambiguous to safely replace in free text — they
+//     appear as substrings in countless unrelated contexts.
+//  2. Generic skip words: common English/infra terms in genericSkipWords (e.g.
+//     "service", "proxy") are never replaced in free text, even after Phase 1 discovery.
+//  3. Plain word (letters-only, single case): avoids replacing generic lowercase
+//     or uppercase words that appear everywhere in logs. Skipped for Phase 1
+//     discoveries so private names like "johndoe" are fully replaced.
+//  4. Known infra components: hyphenated names like "cloud-controller-manager"
+//     that are both Azure identity names and Kubernetes component names.
+//  5. Semantic version: strings like "4.19.18" that look like resource names
+//     but are version numbers.
+func shouldSkipFreeTextReplacement(s string, foundViaPhase1 bool) bool {
+	if len(s) < 5 {
+		return true
+	}
+	if isSkipListWord(s) {
+		return true
+	}
+	if !foundViaPhase1 && isPlainWord(s) {
+		return true
+	}
+	if _, ok := knownInfraComponents[s]; ok {
+		return true
+	}
+	if semVerPattern.MatchString(s) {
+		return true
+	}
+	return false
+}
+
+type protectedRange struct {
+	start, end int
+}
+
+// findProtectedRanges pre-computes all compound token locations in text.
+func findProtectedRanges(text string) []protectedRange {
+	var ranges []protectedRange
+	for _, p := range protectedPatterns {
+		for _, loc := range p.FindAllStringIndex(text, -1) {
+			ranges = append(ranges, protectedRange{start: loc[0], end: loc[1]})
+		}
+	}
+	return ranges
+}
+
+// isProtectedByRanges returns true if the match at [start, end) is a
+// strict subset of any pre-computed protected range.
+func isProtectedByRanges(ranges []protectedRange, start, end int) bool {
+	for _, r := range ranges {
+		if r.start <= start && end <= r.end && (r.start < start || end < r.end) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/obfuscator/protected_test.go
+++ b/pkg/obfuscator/protected_test.go
@@ -1,0 +1,137 @@
+package obfuscator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSkipListWord(t *testing.T) {
+	for _, tc := range []struct {
+		input    string
+		expected bool
+	}{
+		{"service", true},
+		{"cluster", true},
+		{"proxy", true},
+		{"Service", false},  // case-sensitive — uppercase not in list
+		{"my-service", false},
+		{"customname", false},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.expected, isSkipListWord(tc.input))
+		})
+	}
+}
+
+func TestShouldSkipFreeTextReplacement(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// Too short (< 5 chars)
+		{"short: vm", "vm", true},
+		{"short: rg", "rg", true},
+		// Plain word — single-case, letters-only (covers all genericSkipWords)
+		{"plain lowercase: service", "service", true},
+		{"plain uppercase: PROXY", "PROXY", true},
+		{"plain uppercase: GPU", "GPU", true},
+		// Known infra components
+		{"infra: cloud-controller-manager", "cloud-controller-manager", true},
+		{"infra: disk-csi-driver", "disk-csi-driver", true},
+		{"infra: image-registry", "image-registry", true},
+		{"infra: control-plane", "control-plane", true},
+		// Semantic versions
+		{"semver: 4.19.18", "4.19.18", true},
+		{"semver: 1.2.3", "1.2.3", true},
+		{"semver: v1.28.5", "v1.28.5", true},
+		{"semver: 4.19.20-rc1", "4.19.20-rc1", true},
+		// Boundary: exactly 4 chars (too short)
+		{"boundary: 4 chars", "abcd", true},
+		// Boundary: exactly 5 chars plain word (still skipped — plain word guard)
+		{"boundary: 5 chars plain", "hello", true},
+		// Boundary: exactly 5 chars mixed case (valid resource name)
+		{"boundary: 5 chars mixed case", "Hello", false},
+		// Should NOT skip — valid resource names
+		{"mixed case: Service", "Service", false},
+		{"hyphenated: my-cluster", "my-cluster", false},
+		{"with digit: proxy1", "proxy1", false},
+		{"camelCase: MyDisk", "MyDisk", false},
+		// These were once in knownInfraComponents but are not standard enough
+		// for an upstream tool — they must now be treated as replaceable resource names.
+		{"formerly-private: cluster-service", "cluster-service", false},
+		{"formerly-private: credential-refresher", "credential-refresher", false},
+		{"formerly-private: secret-sync-controller", "secret-sync-controller", false},
+		{"formerly-private: route-monitor-operator", "route-monitor-operator", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, shouldSkipFreeTextReplacement(tc.input, false))
+		})
+	}
+
+	// foundViaPhase1=true: isPlainWord guard is bypassed, but other guards remain.
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// Plain lowercase bypassed by Phase 1 → should NOT skip
+		{"phase1 plain: johndoe", "johndoe", false},
+		{"phase1 plain: customer", "customer", false},
+		// genericSkipWords always block, even Phase 1 discoveries
+		{"phase1 genericSkip: service", "service", true},
+		{"phase1 genericSkip: proxy", "proxy", true},
+		// knownInfraComponents always block, even Phase 1 discoveries
+		{"phase1 infra: disk-csi-driver", "disk-csi-driver", true},
+		{"phase1 infra: image-registry", "image-registry", true},
+		// Too short — always block
+		{"phase1 short: vm", "vm", true},
+		// semver — always block
+		{"phase1 semver: 4.19.18", "4.19.18", true},
+		// Mixed case — never blocked by isPlainWord anyway
+		{"phase1 mixed: Service", "Service", false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, shouldSkipFreeTextReplacement(tc.input, true))
+		})
+	}
+}
+
+func TestIsProtectedContext(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		text     string
+		start    int
+		end      int
+		expected bool
+	}{
+		// Dotted compounds
+		{"systemd unit", "containerd.service is running", 11, 18, true},
+		{"CRD name", "destinationrules.networking.istio.io", 17, 27, true},
+
+		// Hyphenated compounds
+		{"kube compound", "kube-apiserver started", 5, 14, true},
+		{"credential-refresher", "msi-credential-refresher ns", 4, 14, true},
+		{"service-worker", "service-worker pool", 0, 7, true},
+		{"clusters-service", "clusters-service running", 9, 16, true},
+
+		// Exact match of entire compound — not protected (strict subset only)
+		{"exact match hyphen", "kube-proxy running", 0, 10, false},
+		{"exact match dot", "containerd.service ok", 0, 18, false},
+
+		// Overlapping hyphenated+dotted compound
+		{"dotted-hyphenated overlap: apiserver in kube-apiserver.service", "kube-apiserver.service is running", 5, 14, true},
+		{"dotted-hyphenated overlap: service in kube-apiserver.service", "kube-apiserver.service is running", 15, 22, true},
+
+		// Standalone word — not protected
+		{"standalone", "apiserver started", 0, 9, false},
+		{"standalone service", "the service is up", 4, 11, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ranges := findProtectedRanges(tc.text)
+			require.Equal(t, tc.expected, isProtectedByRanges(ranges, tc.start, tc.end))
+		})
+	}
+}

--- a/pkg/obfuscator/seeding.go
+++ b/pkg/obfuscator/seeding.go
@@ -1,0 +1,172 @@
+package obfuscator
+
+import (
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// compoundPattern matches word-like tokens bounded by non-word/non-hyphen characters.
+// Note: underscores are accepted internally (e.g. "consumer_name" matches as one token),
+// but segmentPattern requires hyphen boundaries so underscore-joined tokens are rejected
+// downstream and never seeded as compounds.
+var compoundPattern = regexp.MustCompile(`[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]|[a-zA-Z0-9]`)
+
+// ExtractClusterToken finds the unique cluster identifier token from a list
+// of must-gather file basenames. Returns "" if no mixed-alphanumeric cluster
+// ID can be extracted (e.g., staging/prod where the ID is a region name).
+func ExtractClusterToken(fileNames []string) string {
+	_, token := ExtractClusterInfo(fileNames)
+	return token
+}
+
+// ExtractClusterInfo returns both the common file name prefix (e.g.,
+// "dev-wx5r9ktl-svc") and the unique cluster token (e.g., "wx5r9ktl").
+// The prefix should be seeded as a canonical for path obfuscation; the
+// token is used for compound discovery in file contents.
+//
+// Must-gather file names follow the pattern:
+//
+//	<env>-<clusterID>-<type>[-<stamp>]-<namespace>-<pod>.jsonl
+//
+// where <type> is "svc" or "mgmt" and <stamp> is an optional digit.
+// The cluster ID is everything between the environment and the type.
+func ExtractClusterInfo(fileNames []string) (prefix, token string) {
+	if len(fileNames) == 0 {
+		return "", ""
+	}
+
+	bases := make([]string, len(fileNames))
+	for i, f := range fileNames {
+		bases[i] = strings.TrimSuffix(filepath.Base(f), filepath.Ext(f))
+	}
+
+	prefix = longestCommonPrefix(bases)
+	prefix = strings.TrimRight(prefix, "-")
+	if prefix == "" {
+		return "", ""
+	}
+
+	_, clusterID, _ := parseClusterPrefix(prefix)
+	if clusterID == "" {
+		return prefix, ""
+	}
+
+	if hasMixedAlphanumeric(clusterID) {
+		return prefix, clusterID
+	}
+	return prefix, ""
+}
+
+// parseClusterPrefix splits a prefix like "dev-wx5r9ktl-svc" into its
+// structural components: environment, cluster ID, and cluster type.
+// Returns empty strings if the prefix doesn't match the expected structure.
+func parseClusterPrefix(prefix string) (env, clusterID, clusterType string) {
+	segments := strings.Split(prefix, "-")
+	if len(segments) < 3 {
+		return "", "", ""
+	}
+
+	env = segments[0]
+
+	// Find "svc" or "mgmt" from the right — that's the cluster type boundary.
+	// Skip trailing numeric stamps (e.g., the "1" in "tst-northeu-svc-1").
+	typeIdx := -1
+	for i := len(segments) - 1; i >= 1; i-- {
+		if isNumeric(segments[i]) {
+			continue
+		}
+		if segments[i] == "svc" || segments[i] == "mgmt" {
+			typeIdx = i
+			break
+		}
+		break
+	}
+
+	if typeIdx < 2 {
+		return "", "", ""
+	}
+
+	clusterID = strings.Join(segments[1:typeIdx], "-")
+	clusterType = segments[typeIdx]
+	return env, clusterID, clusterType
+}
+
+func longestCommonPrefix(strs []string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	prefix := strs[0]
+	for _, s := range strs[1:] {
+		for !strings.HasPrefix(s, prefix) {
+			prefix = prefix[:len(prefix)-1]
+			if prefix == "" {
+				return ""
+			}
+		}
+	}
+	return prefix
+}
+
+func isNumeric(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// hasMixedAlphanumeric returns true if s contains both letters and digits.
+// Pure-letter strings like "uksouth" (Azure region names) return false.
+func hasMixedAlphanumeric(s string) bool {
+	hasLetter := false
+	hasDigit := false
+	for _, c := range s {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+			hasLetter = true
+		}
+		if c >= '0' && c <= '9' {
+			hasDigit = true
+		}
+	}
+	return hasLetter && hasDigit
+}
+
+// DiscoverSensitiveCompounds finds all compound strings in text that contain
+// the given token as a complete hyphen-delimited segment. A compound is a
+// sequence of word characters and hyphens, bounded by non-word/non-hyphen
+// characters (quotes, whitespace, dots, equals, brackets, etc.) or
+// start/end of string.
+func DiscoverSensitiveCompounds(text, token string, segmentPattern *regexp.Regexp) []string {
+	if !strings.Contains(text, token) {
+		return nil
+	}
+
+	decoded := text
+	if strings.Contains(text, "%") {
+		if d, err := url.QueryUnescape(text); err == nil {
+			decoded = d
+		}
+	}
+
+	seen := map[string]struct{}{}
+	var results []string
+
+	for _, match := range compoundPattern.FindAllString(decoded, -1) {
+		if !segmentPattern.MatchString(match) {
+			continue
+		}
+		if _, ok := seen[match]; ok {
+			continue
+		}
+		seen[match] = struct{}{}
+		results = append(results, match)
+	}
+
+	return results
+}

--- a/pkg/obfuscator/seeding_test.go
+++ b/pkg/obfuscator/seeding_test.go
@@ -1,0 +1,283 @@
+package obfuscator
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractClusterToken(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		files    []string
+		expected string
+	}{
+		// --- Personal/development environments (mixed-alphanumeric cluster IDs) ---
+		{
+			name: "dev env: wx5r9ktl extracted",
+			files: []string{
+				"dev-wx5r9ktl-svc-acrpull-acrpull-controller.jsonl",
+				"dev-wx5r9ktl-svc-aks-istio-ingress-istio-proxy.jsonl",
+				"dev-wx5r9ktl-svc-clusters-service-clusters-service-server.jsonl",
+				"dev-wx5r9ktl-svc-kube-system-coredns.jsonl",
+			},
+			expected: "wx5r9ktl",
+		},
+		{
+			name:     "single file: prefix includes namespace, no structural match",
+			files:    []string{"dev-wx5r9ktl-svc-foo.jsonl"},
+			expected: "",
+		},
+		{
+			name: "prow env: j-prefixed BUILD_ID extracted",
+			files: []string{
+				"prow-j1234567-svc-kube-system-coredns.jsonl",
+				"prow-j1234567-svc-acrpull-acrpull-controller.jsonl",
+			},
+			expected: "j1234567",
+		},
+		{
+			name: "perf env: p-prefixed user suffix extracted",
+			files: []string{
+				"perf-zk8m2nvq-svc-kube-system-coredns.jsonl",
+				"perf-zk8m2nvq-svc-acrpull-acrpull-controller.jsonl",
+			},
+			expected: "zk8m2nvq",
+		},
+		// --- Staging/production environments (pure-letter region names → no token) ---
+		{
+			name: "tst env: northeu is pure letters, no token",
+			files: []string{
+				"tst-northeu-svc-1-acrpull-acrpull-controller.jsonl",
+				"tst-northeu-svc-1-kube-system-coredns.jsonl",
+			},
+			expected: "",
+		},
+		{
+			name: "prod env: eastus is pure letters, no token",
+			files: []string{
+				"prod-eastus-svc-2-acrpull-acrpull-controller.jsonl",
+				"prod-eastus-svc-2-kube-system-coredns.jsonl",
+			},
+			expected: "",
+		},
+		{
+			name: "int env: northeu is pure letters, no token",
+			files: []string{
+				"int-northeu-svc-1-kube-system-coredns.jsonl",
+				"int-northeu-svc-1-acrpull-acrpull-controller.jsonl",
+			},
+			expected: "",
+		},
+		// --- Management clusters ---
+		{
+			name: "mgmt cluster: pers env with stamp",
+			files: []string{
+				"dev-wx5r9ktl-mgmt-1-kube-system-coredns.jsonl",
+				"dev-wx5r9ktl-mgmt-1-acrpull-acrpull-controller.jsonl",
+			},
+			expected: "wx5r9ktl",
+		},
+		{
+			name: "mgmt cluster: stg env with stamp",
+			files: []string{
+				"tst-northeu-mgmt-1-kube-system-coredns.jsonl",
+				"tst-northeu-mgmt-1-acrpull-acrpull-controller.jsonl",
+			},
+			expected: "",
+		},
+		// --- Edge cases ---
+		{
+			name:     "empty file list",
+			files:    []string{},
+			expected: "",
+		},
+		{
+			name: "no common prefix",
+			files: []string{
+				"alpha-foo.jsonl",
+				"bravo-bar.jsonl",
+			},
+			expected: "",
+		},
+		{
+			name: "prefix too short for structure",
+			files: []string{
+				"ab-xy.jsonl",
+				"ab-xz.jsonl",
+			},
+			expected: "",
+		},
+		{
+			name: "multi-segment cluster ID extracted",
+			files: []string{
+				"env-seg1-seg2-svc-kube-system-coredns.jsonl",
+				"env-seg1-seg2-svc-acrpull-controller.jsonl",
+			},
+			expected: "seg1-seg2",
+		},
+		{
+			name: "no svc or mgmt type marker",
+			files: []string{
+				"env-clusterid-other-foo.jsonl",
+				"env-clusterid-other-bar.jsonl",
+			},
+			expected: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ExtractClusterToken(tc.files)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestExtractClusterInfo(t *testing.T) {
+	t.Run("dev env returns prefix and token", func(t *testing.T) {
+		files := []string{
+			"dev-wx5r9ktl-svc-acrpull-acrpull-controller.jsonl",
+			"dev-wx5r9ktl-svc-kube-system-coredns.jsonl",
+		}
+		prefix, token := ExtractClusterInfo(files)
+		require.Equal(t, "dev-wx5r9ktl-svc", prefix)
+		require.Equal(t, "wx5r9ktl", token)
+	})
+
+	t.Run("staging env returns prefix but no token", func(t *testing.T) {
+		files := []string{
+			"tst-northeu-svc-1-acrpull-acrpull-controller.jsonl",
+			"tst-northeu-svc-1-kube-system-coredns.jsonl",
+		}
+		prefix, token := ExtractClusterInfo(files)
+		require.Equal(t, "tst-northeu-svc-1", prefix)
+		require.Equal(t, "", token)
+	})
+
+	t.Run("prow env returns prefix and token", func(t *testing.T) {
+		files := []string{
+			"prow-j1234567-svc-kube-system-coredns.jsonl",
+			"prow-j1234567-svc-acrpull-acrpull-controller.jsonl",
+		}
+		prefix, token := ExtractClusterInfo(files)
+		require.Equal(t, "prow-j1234567-svc", prefix)
+		require.Equal(t, "j1234567", token)
+	})
+
+	t.Run("mgmt cluster with stamp returns prefix and token", func(t *testing.T) {
+		files := []string{
+			"dev-wx5r9ktl-mgmt-1-kube-system-coredns.jsonl",
+			"dev-wx5r9ktl-mgmt-1-acrpull-acrpull-controller.jsonl",
+		}
+		prefix, token := ExtractClusterInfo(files)
+		require.Equal(t, "dev-wx5r9ktl-mgmt-1", prefix)
+		require.Equal(t, "wx5r9ktl", token)
+	})
+}
+
+func TestParseClusterPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		prefix      string
+		expectedEnv string
+		expectedID  string
+		expectedTyp string
+	}{
+		{"dev svc", "dev-wx5r9ktl-svc", "dev", "wx5r9ktl", "svc"},
+		{"tst svc with stamp", "tst-northeu-svc-1", "tst", "northeu", "svc"},
+		{"prod svc with stamp", "prod-eastus-svc-2", "prod", "eastus", "svc"},
+		{"dev mgmt with stamp", "dev-wx5r9ktl-mgmt-1", "dev", "wx5r9ktl", "mgmt"},
+		{"prow svc", "prow-j1234567-svc", "prow", "j1234567", "svc"},
+		{"int svc with stamp", "int-northeu-svc-1", "int", "northeu", "svc"},
+		{"too short", "ab-xy", "", "", ""},
+		{"no type marker", "env-cluster-other", "", "", ""},
+		{"only two segments", "env-svc", "", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env, id, typ := parseClusterPrefix(tc.prefix)
+			require.Equal(t, tc.expectedEnv, env)
+			require.Equal(t, tc.expectedID, id)
+			require.Equal(t, tc.expectedTyp, typ)
+		})
+	}
+}
+
+func TestDiscoverSensitiveCompounds(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		text     string
+		token    string
+		expected []string
+	}{
+		{
+			name:     "consumer_name with single quotes",
+			text:     `consumer_name='hcp-underlay-wx5r9ktl-mgmt-1' and status=active`,
+			token:    "wx5r9ktl",
+			expected: []string{"hcp-underlay-wx5r9ktl-mgmt-1"},
+		},
+		{
+			name:     "URL-encoded quotes",
+			text:     `%27dev-wx5r9ktl-svc%27`,
+			token:    "wx5r9ktl",
+			expected: []string{"dev-wx5r9ktl-svc"},
+		},
+		{
+			name:     "monitoring hostname with dots",
+			text:     `msprom-westus3-dev-wx5r9ktl-svc-0vyy.westus3-1.metrics.ingest.monitor.azure.com`,
+			token:    "wx5r9ktl",
+			expected: []string{"msprom-westus3-dev-wx5r9ktl-svc-0vyy"},
+		},
+		{
+			name:     "no false positive without hyphen boundary",
+			text:     `xwx5r9ktly is not a match`,
+			token:    "wx5r9ktl",
+			expected: nil,
+		},
+		{
+			name:     "double-quoted JSON value",
+			text:     `"clusterName":"dev-wx5r9ktl-svc"`,
+			token:    "wx5r9ktl",
+			expected: []string{"dev-wx5r9ktl-svc"},
+		},
+		{
+			name:     "multiple compounds in one line",
+			text:     `source='arohcpdev-wx5r9ktl' consumer='hcp-underlay-wx5r9ktl-mgmt-1'`,
+			token:    "wx5r9ktl",
+			expected: []string{"arohcpdev-wx5r9ktl", "hcp-underlay-wx5r9ktl-mgmt-1"},
+		},
+		{
+			name:     "token at start of compound",
+			text:     `wx5r9ktl-svc is running`,
+			token:    "wx5r9ktl",
+			expected: []string{"wx5r9ktl-svc"},
+		},
+		{
+			name:     "token at end of compound",
+			text:     `cluster dev-wx5r9ktl ready`,
+			token:    "wx5r9ktl",
+			expected: []string{"dev-wx5r9ktl"},
+		},
+		{
+			name:     "standalone token is also a compound",
+			text:     `token wx5r9ktl alone`,
+			token:    "wx5r9ktl",
+			expected: []string{"wx5r9ktl"},
+		},
+		{
+			name:     "token not present",
+			text:     `nothing sensitive here`,
+			token:    "wx5r9ktl",
+			expected: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			segPat := regexp.MustCompile(`(?:^|-)` + regexp.QuoteMeta(tc.token) + `(?:-|$)`)
+			result := DiscoverSensitiveCompounds(tc.text, tc.token, segPat)
+			if tc.expected == nil {
+				require.Empty(t, result)
+			} else {
+				require.ElementsMatch(t, tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
  ## Summary      
                                                                                                                                                                                
  - Azure resource names like "service", "network", or "proxy" discovered from ARM                                                                                              
    paths were being blindly replaced in all free text via strings.ReplaceAll, corrupting                                                                                       
    unrelated strings (e.g. "containerd.service" → "containerd.obfuscated-resource-name")                                                                                       
  - Keywords obfuscator had the same substring problem — a keyword like "dns" would match                                                                                       
    inside "coredns"                                                                                                                                                            
                                                                                                                                                                                
  ## Fix                                                                                                                                                                        
                                                                                                                                                                                
  - **Keywords obfuscator**: switched from strings.ReplaceAll to \b-bounded regex matching,                                                                                     
    so replacements respect word boundaries (underscores and digits are word characters;
    dots and hyphens are boundaries)                                                                                                                                            
  - **Azure resource obfuscator**: added two guards for free-text replacement:                                                                                                  
    1. `replaceNotInsideWord` — skips matches embedded inside larger alphabetic tokens                                                                                          
       (e.g. "Proxy1" inside "MyProxy1Handler")                                                                                                                                 
    2. `isGenericWord` — skips single-case alphabetic strings ("service", "GPU") that are                                                                                       
       too common to safely replace in free text                                                                                                                                
    3. Short canonicals (< 5 chars) are skipped entirely ("0", "vm", "rg")                                                                                                      
                                                                                                                                                                                
  ## Test plan                                                                                                                                                                  
                                                                                                                                                                                
  - [ ] New test: "service" discovered from ARM path does not corrupt "containerd.service"                                                                                      
  - [ ] New test: keyword "dns" does not match inside "coredns"
  - [ ] Edge case tests for: mixed-case identifiers, digit suffixes, URL-encoded strings,                                                                                       
        hyphenated names, multiple occurrences, embedded-in-token protection                                                                                                    
  - [ ] Word boundary semantics verified for: dots, hyphens, underscores, colons, equals, digits                                                                                
  - [ ] `go build ./...` and `go test ./pkg/obfuscator/...` pass