### PR TITLE
Add tar-aware processing for .tar.gz and .tgz archives.

### DIFF
--- a/pkg/cleaner/cleaning.go
+++ b/pkg/cleaner/cleaning.go
@@ -142,23 +142,8 @@ func (c *FileContentObfuscator) ObfuscateFile(inputFile string, outputFile strin
 		}
 	}
 
-	// tar archives need entry-level processing instead of treating the whole binary stream as text
-	if strings.HasSuffix(readPath, ".tar.gz") || strings.HasSuffix(readPath, ".tgz") {
-		err = c.obfuscateTarGz(inputOsFile, outputOsFile, readPath, reportOnly)
-		if err != nil {
-			return fmt.Errorf("failed to obfuscate tar archive '%s': %w", readPath, err)
-		}
-		if err = inputOsFile.Close(); err != nil {
-			return fmt.Errorf("failed to close input file '%s': %w", readPath, err)
-		}
-		if err = outputOsFile.Close(); err != nil {
-			return fmt.Errorf("failed to close output file '%s': %w", writePath, err)
-		}
-		return nil
-	}
-
-	// must-gathers can include gunzipped log files nowadays, handling this special case here once
-	if strings.HasSuffix(readPath, ".gz") {
+	// must-gathers can include gzipped files, handling decompression/recompression here
+	if strings.HasSuffix(readPath, ".gz") || strings.HasSuffix(readPath, ".tgz") {
 		inputOsFile, err = gzip.NewReader(inputOsFile)
 		if err != nil {
 			return fmt.Errorf("failed to create a gzip reader when opening '%s': %w", readPath, err)
@@ -169,7 +154,12 @@ func (c *FileContentObfuscator) ObfuscateFile(inputFile string, outputFile strin
 		}
 	}
 
-	err = c.ObfuscateReader(inputOsFile, outputOsFile)
+	// tar archives need entry-level processing instead of treating the whole binary stream as text
+	if strings.HasSuffix(readPath, ".tar.gz") || strings.HasSuffix(readPath, ".tgz") {
+		err = c.obfuscateTar(inputOsFile, outputOsFile)
+	} else {
+		err = c.ObfuscateReader(inputOsFile, outputOsFile)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to obfuscate input file '%s': %w", readPath, err)
 	}
@@ -206,21 +196,10 @@ func (c *FileContentObfuscator) createNonConflictingFileUnderLock(outputFilePath
 	return fsutil.CreateNonConflictingFile(outputFilePath, inputFileInfo)
 }
 
-func (c *ContentObfuscator) obfuscateTarGz(input io.Reader, output io.Writer, readPath string, reportOnly bool) error {
-	gzReader, err := gzip.NewReader(input)
-	if err != nil {
-		return fmt.Errorf("failed to create a gzip reader for '%s': %w", readPath, err)
-	}
-	defer gzReader.Close()
-
-	tarReader := tar.NewReader(gzReader)
-
-	var tarWriter *tar.Writer
-	var gzWriter *gzip.Writer
-	if !reportOnly {
-		gzWriter = gzip.NewWriter(output)
-		tarWriter = tar.NewWriter(gzWriter)
-	}
+func (c *ContentObfuscator) obfuscateTar(input io.Reader, output io.Writer) (err error) {
+	tarReader := tar.NewReader(input)
+	tarWriter := tar.NewWriter(output)
+	defer func() { err = errors.Join(err, tarWriter.Close()) }()
 
 	for {
 		header, err := tarReader.Next()
@@ -228,28 +207,19 @@ func (c *ContentObfuscator) obfuscateTarGz(input io.Reader, output io.Writer, re
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("failed to read tar entry in '%s': %w", readPath, err)
+			return fmt.Errorf("failed to read tar entry '%w'", err)
 		}
 
 		if header.Typeflag != tar.TypeReg {
-			if tarWriter != nil {
-				if err := tarWriter.WriteHeader(header); err != nil {
-					return err
-				}
-			}
-			continue
-		}
-
-		if reportOnly {
-			if err := c.ObfuscateReader(tarReader, io.Discard); err != nil {
-				return fmt.Errorf("failed to obfuscate tar entry '%s' in '%s': %w", header.Name, readPath, err)
+			if err := tarWriter.WriteHeader(header); err != nil {
+				return err
 			}
 			continue
 		}
 
 		var obfuscated bytes.Buffer
 		if err := c.ObfuscateReader(tarReader, &obfuscated); err != nil {
-			return fmt.Errorf("failed to obfuscate tar entry '%s' in '%s': %w", header.Name, readPath, err)
+			return fmt.Errorf("failed to obfuscate tar entry '%s': %w", header.Name, err)
 		}
 
 		header.Size = int64(obfuscated.Len())
@@ -257,15 +227,6 @@ func (c *ContentObfuscator) obfuscateTarGz(input io.Reader, output io.Writer, re
 			return err
 		}
 		if _, err := io.Copy(tarWriter, &obfuscated); err != nil {
-			return err
-		}
-	}
-
-	if tarWriter != nil {
-		if err := tarWriter.Close(); err != nil {
-			return err
-		}
-		if err := gzWriter.Close(); err != nil {
 			return err
 		}
 	}

--- a/pkg/cleaner/cleaning.go
+++ b/pkg/cleaner/cleaning.go
@@ -2,7 +2,9 @@
 package cleaner
 
 import (
+	"archive/tar"
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"errors"
 	"fmt"
@@ -140,8 +142,23 @@ func (c *FileContentObfuscator) ObfuscateFile(inputFile string, outputFile strin
 		}
 	}
 
+	// tar archives need entry-level processing instead of treating the whole binary stream as text
+	if strings.HasSuffix(readPath, ".tar.gz") || strings.HasSuffix(readPath, ".tgz") {
+		err = c.obfuscateTarGz(inputOsFile, outputOsFile, readPath, reportOnly)
+		if err != nil {
+			return fmt.Errorf("failed to obfuscate tar archive '%s': %w", readPath, err)
+		}
+		if err = inputOsFile.Close(); err != nil {
+			return fmt.Errorf("failed to close input file '%s': %w", readPath, err)
+		}
+		if err = outputOsFile.Close(); err != nil {
+			return fmt.Errorf("failed to close output file '%s': %w", writePath, err)
+		}
+		return nil
+	}
+
 	// must-gathers can include gunzipped log files nowadays, handling this special case here once
-	if strings.HasSuffix(readPath, ".gz") || strings.HasSuffix(readPath, ".tgz") {
+	if strings.HasSuffix(readPath, ".gz") {
 		inputOsFile, err = gzip.NewReader(inputOsFile)
 		if err != nil {
 			return fmt.Errorf("failed to create a gzip reader when opening '%s': %w", readPath, err)
@@ -187,6 +204,73 @@ func (c *FileContentObfuscator) createNonConflictingFileUnderLock(outputFilePath
 	defer c.pathCollisionMutex.Unlock()
 
 	return fsutil.CreateNonConflictingFile(outputFilePath, inputFileInfo)
+}
+
+func (c *ContentObfuscator) obfuscateTarGz(input io.Reader, output io.Writer, readPath string, reportOnly bool) error {
+	gzReader, err := gzip.NewReader(input)
+	if err != nil {
+		return fmt.Errorf("failed to create a gzip reader for '%s': %w", readPath, err)
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+
+	var tarWriter *tar.Writer
+	var gzWriter *gzip.Writer
+	if !reportOnly {
+		gzWriter = gzip.NewWriter(output)
+		tarWriter = tar.NewWriter(gzWriter)
+	}
+
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar entry in '%s': %w", readPath, err)
+		}
+
+		if header.Typeflag != tar.TypeReg {
+			if tarWriter != nil {
+				if err := tarWriter.WriteHeader(header); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		if reportOnly {
+			if err := c.ObfuscateReader(tarReader, io.Discard); err != nil {
+				return fmt.Errorf("failed to obfuscate tar entry '%s' in '%s': %w", header.Name, readPath, err)
+			}
+			continue
+		}
+
+		var obfuscated bytes.Buffer
+		if err := c.ObfuscateReader(tarReader, &obfuscated); err != nil {
+			return fmt.Errorf("failed to obfuscate tar entry '%s' in '%s': %w", header.Name, readPath, err)
+		}
+
+		header.Size = int64(obfuscated.Len())
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+		if _, err := io.Copy(tarWriter, &obfuscated); err != nil {
+			return err
+		}
+	}
+
+	if tarWriter != nil {
+		if err := tarWriter.Close(); err != nil {
+			return err
+		}
+		if err := gzWriter.Close(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (c *ContentObfuscator) ObfuscateReader(inputReader io.Reader, outputWriter io.Writer) error {

--- a/pkg/cleaner/cleaning_test.go
+++ b/pkg/cleaner/cleaning_test.go
@@ -1,7 +1,11 @@
 package cleaner
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -312,6 +316,127 @@ metadata:
 		})
 	}
 
+}
+
+func createTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	for name, content := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Size:     int64(len(content)),
+			Mode:     0644,
+			Typeflag: tar.TypeReg,
+		}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+	return buf.Bytes()
+}
+
+func readTarGz(t *testing.T, data []byte) map[string]string {
+	t.Helper()
+	gzr, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	tr := tar.NewReader(gzr)
+	files := make(map[string]string)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		if header.Typeflag == tar.TypeReg {
+			content, err := io.ReadAll(tr)
+			require.NoError(t, err)
+			files[header.Name] = string(content)
+		}
+	}
+	return files
+}
+
+func TestObfuscateTarGzFile(t *testing.T) {
+	tmpInputDir, err := os.MkdirTemp("", "tar-test-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpInputDir) }()
+
+	tmpOutputDir, err := os.MkdirTemp("", "tar-test-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpOutputDir) }()
+
+	tarData := createTarGz(t, map[string]string{
+		"log.txt": "connection from 192.168.1.1 established\n",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(tmpInputDir, "archive.tar.gz"), tarData, 0644))
+
+	fco := &FileContentObfuscator{
+		ContentObfuscator: ContentObfuscator{Obfuscator: noErrorIpObfuscator(t)},
+		inputFolder:       tmpInputDir,
+		outputFolder:      tmpOutputDir,
+	}
+
+	err = fco.ObfuscateFile("archive.tar.gz", "archive.tar.gz")
+	require.NoError(t, err)
+
+	outputData, err := os.ReadFile(filepath.Join(tmpOutputDir, "archive.tar.gz"))
+	require.NoError(t, err)
+
+	result := readTarGz(t, outputData)
+	assert.Equal(t, "connection from xxx.xxx.xxx.xxx established\n", result["log.txt"])
+}
+
+func TestObfuscateTgzFile(t *testing.T) {
+	tmpInputDir, err := os.MkdirTemp("", "tar-test-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpInputDir) }()
+
+	tmpOutputDir, err := os.MkdirTemp("", "tar-test-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpOutputDir) }()
+
+	tarData := createTarGz(t, map[string]string{
+		"data.json": `{"ip": "10.0.0.1"}` + "\n",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(tmpInputDir, "bundle.tgz"), tarData, 0644))
+
+	fco := &FileContentObfuscator{
+		ContentObfuscator: ContentObfuscator{Obfuscator: noErrorIpObfuscator(t)},
+		inputFolder:       tmpInputDir,
+		outputFolder:      tmpOutputDir,
+	}
+
+	err = fco.ObfuscateFile("bundle.tgz", "bundle.tgz")
+	require.NoError(t, err)
+
+	outputData, err := os.ReadFile(filepath.Join(tmpOutputDir, "bundle.tgz"))
+	require.NoError(t, err)
+
+	result := readTarGz(t, outputData)
+	assert.Equal(t, `{"ip": "xxx.xxx.xxx.xxx"}`+"\n", result["data.json"])
+}
+
+func TestObfuscateTarGzReportOnly(t *testing.T) {
+	tmpInputDir, err := os.MkdirTemp("", "tar-test-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpInputDir) }()
+
+	tarData := createTarGz(t, map[string]string{
+		"log.txt": "connection from 192.168.1.1 established\n",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(tmpInputDir, "archive.tar.gz"), tarData, 0644))
+
+	fco := &FileContentObfuscator{
+		ContentObfuscator: ContentObfuscator{Obfuscator: noErrorIpObfuscator(t)},
+		inputFolder:       tmpInputDir,
+		outputFolder:      "",
+	}
+
+	err = fco.ObfuscateFile("archive.tar.gz", "archive.tar.gz")
+	require.NoError(t, err)
 }
 
 func newFilePatternOmitter(t *testing.T, pattern string) omitter.FileOmitter {


### PR DESCRIPTION
 Previously, tar.gz/.tgz files were decompressed as plain gzip and the raw tar binary stream was treated as text for obfuscation, which was incorrect and cause the cleaned file to become corrupted. Now tar entries are iterated individually and each file entry is obfuscated separately.

Added some tests as well.

Example:

> tar zxvf ovnk_database_store.tar.gz
> x ovnk_database_store/
> x ovnk_database_store/ovnkube-node-2s8ft_sbdb
> tar: Damaged tar archive
> tar: Retrying...
> tar: Damaged tar archive
> tar: Retrying...