### PR TITLE
The previous FindAllString + strings.ReplaceAll loop was very slow O(n*m)

### DIFF
--- a/pkg/obfuscator/domain.go
+++ b/pkg/obfuscator/domain.go
@@ -33,23 +33,19 @@ func (d *domainObfuscator) Contents(s string) string {
 func (d *domainObfuscator) replaceDomains(input string) string {
 	output := input
 	for _, p := range d.domainPatterns {
-		matches := p.FindAllStringSubmatch(output, -1)
-		for _, m := range matches {
-			if len(m) != 3 {
-				continue
+		output = p.ReplaceAllStringFunc(output, func(match string) string {
+			groups := p.FindStringSubmatch(match)
+			if len(groups) != 3 {
+				return match
 			}
-			baseDomain := m[2]
-			subDomain := m[1]
-			obfuscatedBaseDomain := d.obfsGenerator.generateReplacement(baseDomain, m[0], 1, d.ReplacementTracker)
-			var replacement string
+			baseDomain := groups[2]
+			subDomain := groups[1]
+			obfuscatedBaseDomain := d.obfsGenerator.generateReplacement(baseDomain, match, 1, d.ReplacementTracker)
 			if subDomain != "" {
-				replacement = fmt.Sprintf("%s%s", subDomain, obfuscatedBaseDomain)
-			} else {
-				replacement = obfuscatedBaseDomain
+				return fmt.Sprintf("%s%s", subDomain, obfuscatedBaseDomain)
 			}
-			// TODO(thomas): should just replace that one matching occurrence instead of all
-			output = strings.ReplaceAll(output, m[0], replacement)
-		}
+			return obfuscatedBaseDomain
+		})
 	}
 	return output
 }

--- a/pkg/obfuscator/domain_test.go
+++ b/pkg/obfuscator/domain_test.go
@@ -67,6 +67,25 @@ func TestDomainObfuscatorContents(t *testing.T) {
 				}}},
 		},
 		{
+			name:    "multiple matches per line",
+			domains: []string{"redhat.com", "openshift.com"},
+			input: []string{
+				"connect to api.openshift.com and sso.redhat.com and console.openshift.com",
+			},
+			output: []string{
+				"connect to api.domain0000000001 and sso.domain0000000002 and console.domain0000000001",
+			},
+			report: ReplacementReport{[]Replacement{
+				{Canonical: "openshift.com", ReplacedWith: "domain0000000001", Counter: map[string]uint{
+					"api.openshift.com":     uint(1),
+					"console.openshift.com": uint(1),
+				}},
+				{Canonical: "redhat.com", ReplacedWith: "domain0000000002", Counter: map[string]uint{
+					"sso.redhat.com": uint(1),
+				}},
+			}},
+		},
+		{
 			name:    "multi-level subdomains",
 			domains: []string{"test.com", "test.info", "test.org"},
 			input: []string{

--- a/pkg/obfuscator/ip.go
+++ b/pkg/obfuscator/ip.go
@@ -53,22 +53,17 @@ func (o *ipObfuscator) Contents(s string) string {
 
 func (o *ipObfuscator) replace(s string) string {
 	output := s
-
 	for _, r := range o.replacements {
-		ipMatches := r.pattern.FindAllString(output, -1)
-		for _, m := range ipMatches {
-			// if the match is in the exclude-list then do not replace.
+		output = r.pattern.ReplaceAllStringFunc(output, func(m string) string {
 			if _, ok := excludedIPs[m]; ok {
-				continue
+				return m
 			}
-
 			cleaned := strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(m, "_", "."), "-", "."))
 			if ip := net.ParseIP(cleaned); ip != nil {
-				replacement := r.generator.generateReplacement(cleaned, m, 1, o.ReplacementTracker)
-				// TODO(thomas): should just replace that one matching occurrence instead of all
-				output = strings.ReplaceAll(output, m, replacement)
+				return r.generator.generateReplacement(cleaned, m, 1, o.ReplacementTracker)
 			}
-		}
+			return m
+		})
 	}
 	return output
 }

--- a/pkg/obfuscator/mac_address.go
+++ b/pkg/obfuscator/mac_address.go
@@ -26,14 +26,10 @@ func (m *macAddressObfuscator) Path(s string) string {
 }
 
 func (m *macAddressObfuscator) Contents(s string) string {
-	matches := m.regex.FindAllString(s, -1)
-	for _, mac := range matches {
-		// normalizing the MAC Address string to the Uppercase to avoid the duplicate reporting
+	return m.regex.ReplaceAllStringFunc(s, func(mac string) string {
 		match := strings.ToUpper(strings.ReplaceAll(mac, "-", ":"))
-		replacement := m.obfsGenerator.generateReplacement(match, mac, 1, m.ReplacementTracker)
-		s = strings.ReplaceAll(s, mac, replacement)
-	}
-	return s
+		return m.obfsGenerator.generateReplacement(match, mac, 1, m.ReplacementTracker)
+	})
 }
 
 func NewMacAddressObfuscator(replacementType schema.ObfuscateReplacementType, tracker ReplacementTracker) (ReportingObfuscator, error) {

--- a/pkg/obfuscator/regex.go
+++ b/pkg/obfuscator/regex.go
@@ -20,16 +20,13 @@ func (r *regexObfuscator) Contents(s string) string {
 }
 
 func (r *regexObfuscator) replace(input string) string {
-	output := input
-	matches := r.pattern.FindAllString(input, -1)
-	for _, m := range matches {
+	return r.pattern.ReplaceAllStringFunc(input, func(m string) string {
 		replacement := strings.Repeat("x", len(m))
 		r.GenerateIfAbsent(m, m, 1, func() string {
 			return replacement
 		})
-		output = strings.ReplaceAll(output, m, replacement)
-	}
-	return output
+		return replacement
+	})
 }
 
 func NewRegexObfuscator(pattern string, tracker ReplacementTracker) (ReportingObfuscator, error) {


### PR DESCRIPTION
For each match it rescanned the entire input string. ReplaceAllStringFunc does it in a single pass, which eliminates the bottleneck on multi-megabyte lines found in archives like the OVN database dumps.

It took 45 minutes to process the ovnk_database_store from my lab cluster.

```
I0527 08:30:06.665569   99527 worker.go:38] [Worker 01] Processing must-gather.local.3876317101593225586/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-0196ef0870275ad9e09dadaea36237dad5d6f0ba970959735c800ac53347fdfc/network_logs/ovnk_database_store.tar.gz

I0527 09:15:16.616453   99527 worker.go:48] [Worker 01] Finished processing must-gather.local.3876317101593225586/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-0196ef0870275ad9e09dadaea36237dad5d6f0ba970959735c800ac53347fdfc/network_logs/ovnk_database_store.tar.gz
```

With the changes, it took ~1m 50s.

```
I0527 11:07:14.800502   22257 worker.go:38] [Worker 08] Processing must-gather.local.3876317101593225586/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-0196ef0870275ad9e09dadaea36237dad5d6f0ba970959735c800ac53347fdfc/network_logs/ovnk_database_store.tar.gz

I0527 11:09:05.655657   22257 worker.go:48] [Worker 08] Finished processing must-gather.local.3876317101593225586/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-0196ef0870275ad9e09dadaea36237dad5d6f0ba970959735c800ac53347fdfc/network_logs/ovnk_database_store.tar.gz
```